### PR TITLE
feat: add root_path config for reverse proxy mounting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,9 @@ GITHUB_REPO=neuromechanist/osa
 API_HOST=0.0.0.0
 API_PORT=38528
 
+# Root path for reverse proxy (e.g., /osa for api.osc.earth/osa/)
+ROOT_PATH=/osa
+
 # Number of Uvicorn workers (production)
 API_WORKERS=4
 

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
     # Port allocation: HEDit prod=38427, HEDit dev=38428, OSA prod=38528, OSA dev=38529
     host: str = Field(default="0.0.0.0", description="Server host")
     port: int = Field(default=38528, description="Server port")
+    root_path: str = Field(
+        default="",
+        description="Root path for mounting behind reverse proxy (e.g., '/osa')",
+    )
 
     # CORS Settings
     cors_origins: list[str] = Field(

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -52,6 +52,7 @@ def create_app() -> FastAPI:
         version=settings.app_version,
         description="An extensible AI assistant platform for open science projects",
         lifespan=lifespan,
+        root_path=settings.root_path,
         docs_url="/docs" if settings.debug else None,
         redoc_url="/redoc" if settings.debug else None,
     )


### PR DESCRIPTION
## Summary

Add `ROOT_PATH` configuration to mount the app at a subpath (e.g., `/osa`).

This allows `api.osc.earth/osa/` routing while keeping the root available for other services.

## Changes

- Add `root_path` setting to config (env: `ROOT_PATH`, default: empty)
- Pass `root_path` to FastAPI for proper URL generation behind reverse proxy
- Update `.env.example` with `ROOT_PATH=/osa`

## Usage

Set in `.env` on the server:
```
ROOT_PATH=/osa
```

Apache config:
```apache
ProxyPass /osa/ http://localhost:38528/
ProxyPassReverse /osa/ http://localhost:38528/
```

Result: `https://api.osc.earth/osa/health` works correctly.

## Test Plan
- [x] Linting passes
- [x] Unit tests pass
- [ ] CI passes