### PR TITLE
feat: user-controlled page context toggle

### DIFF
--- a/frontend/osa-chat-widget.js
+++ b/frontend/osa-chat-widget.js
@@ -641,18 +641,17 @@
     }
 
     .osa-page-context-toggle {
-      padding: 8px 16px;
-      border-top: 1px solid var(--osa-border);
-      font-size: 12px;
+      padding: 6px 16px;
+      font-size: 11px;
       color: var(--osa-text-light);
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: 6px;
     }
 
     .osa-page-context-toggle input[type="checkbox"] {
-      width: 14px;
-      height: 14px;
+      width: 11px;
+      height: 11px;
       margin: 0;
       cursor: pointer;
       accent-color: var(--osa-primary);


### PR DESCRIPTION
## Summary

Convert the page context notice from a static info display to an interactive checkbox that users can toggle.

### Changes
- Replace static "Page context enabled" notice with a toggleable checkbox
- Users can opt in/out of sharing their page URL with the assistant
- Preference is persisted in localStorage
- Default: enabled (to help provide better answers)

### UX Improvement
- Before: Static notice that just informed users
- After: Checkbox with label "Share page URL to help answer questions"
- Users have control over their privacy preference

### Config Options
```javascript
allowPageContext: true,           // Show the checkbox option
pageContextDefaultEnabled: true,  // Default state
pageContextStorageKey: 'osa-page-context-enabled',
pageContextLabel: 'Share page URL to help answer questions'
```