### PR TITLE
feat: add token-aware conversation trimming

### DIFF
--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -143,7 +143,6 @@ class BaseAgent(ABC):
                 strategy="last",  # Keep most recent messages
                 token_counter=count_tokens_approximately,
                 start_on="human",  # Ensure we start on a user message
-                end_on=("human", "tool"),  # Valid ending message types
                 include_system=False,  # System prompt handled separately
             )
 

--- a/tests/test_agents/test_base.py
+++ b/tests/test_agents/test_base.py
@@ -238,3 +238,23 @@ class TestTokenTrimming:
 
         # Should only have system prompt
         assert len(messages) == 1
+
+    def test_prepare_messages_preserves_ai_responses(self) -> None:
+        """Trimming should preserve final AI responses, not drop them."""
+        model = FakeListChatModel(responses=["Response"])
+        agent = SimpleAgent(model=model, max_conversation_tokens=500)
+
+        # Conversation ending with AI response (common pattern)
+        messages = [
+            HumanMessage(content="What is HED?"),
+            AIMessage(content="HED is Hierarchical Event Descriptors."),
+        ]
+
+        state = {"messages": messages}
+        result = agent._prepare_messages(state)
+
+        # The AI response should be preserved (not dropped by end_on filter)
+        conversation = result[1:]  # Skip system prompt
+        assert len(conversation) == 2
+        assert isinstance(conversation[-1], AIMessage)
+        assert "HED" in conversation[-1].content


### PR DESCRIPTION
## Summary

Add token-aware conversation trimming to prevent unbounded context growth during multi-turn conversations with tool calls.

## Changes

- Add `trim_messages` to `_prepare_messages` in base agent
- Default `max_conversation_tokens` of 6000 (configurable per agent)
- System prompt always included in full, conversation history trimmed
- Keeps most recent messages when trimming (`strategy='last'`)
- Logs when trimming occurs for debugging

## Token Budget

| Component | Tokens |
|-----------|--------|
| System prompt + preloaded docs | ~14K |
| Conversation history (capped) | 6K |
| **Total per iteration** | **~20K** |

Before: 25K+ and growing with each tool call
After: ~20K flat

## Tests

Added 6 new tests for trimming behavior:
- Default token budget
- Custom token budget
- System prompt always included
- Long conversations are trimmed
- Recent messages preserved
- Empty state handling

## Related

- Addresses #34 (Phase 1 quick wins)