### PR TITLE
docs: add community registry section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ OSA provides domain-specific AI assistants for open science tools with:
 - **EEGLAB Assistant**: EEG analysis toolbox (coming soon)
 
 Features:
+- **YAML-driven community registry** - add a new assistant with just a config file
 - Modular tool system for document retrieval, validation, and code execution
 - Multi-source knowledge bases (GitHub, OpenALEX, Discourse forums, mailing lists)
-- Extensible architecture for adding new assistants and tools
+- Embeddable chat widget for any website
 - Production-ready observability via LangFuse
 
 ## Installation
@@ -95,6 +96,47 @@ curl http://localhost:38528/health
 ```
 
 See [deploy/DEPLOYMENT_ARCHITECTURE.md](deploy/DEPLOYMENT_ARCHITECTURE.md) for detailed deployment options including Apache reverse proxy and BYOK configuration.
+
+## Community Registry
+
+OSA uses a YAML-driven registry to configure community assistants. Each community has a `config.yaml` that declares its documentation, system prompt, knowledge sources, and specialized tools.
+
+```bash
+# Directory structure
+src/assistants/
+    hed/config.yaml      # HED assistant configuration
+    bids/config.yaml     # BIDS assistant (planned)
+```
+
+### Adding a New Community
+
+1. Create `src/assistants/my-tool/config.yaml`:
+
+```yaml
+id: my-tool
+name: My Tool
+description: A research tool for neuroscience
+status: available
+
+system_prompt: |
+  You are a technical assistant for {name}.
+  {preloaded_docs_section}
+  {available_docs_section}
+
+documentation:
+  - title: Getting Started
+    url: https://my-tool.org/docs
+    source_url: https://raw.githubusercontent.com/org/my-tool/main/docs/intro.md
+    preload: true
+
+github:
+  repos:
+    - org/my-tool
+```
+
+2. Start the server - the `/{community-id}/ask` endpoint is auto-created.
+
+See the [full documentation](https://docs.osc.earth/osa/registry/) for schema reference, extensions, and widget deployment.
 
 ## Optional: HED Tag Suggestions
 


### PR DESCRIPTION
## Summary

- Add community registry section to README with quick-start example
- Update features list to highlight YAML-driven registry and embeddable widget

## Context

Part of #49 (Phase 6: Documentation for YAML registry system). The full documentation is in the [documentation repo PR](https://github.com/OpenScience-Collective/documentation/pull/4).

## Test plan

- [x] README renders correctly on GitHub
- [x] Example YAML is valid against CommunityConfig schema