### PR TITLE
fix: allow platform demo origins in API authorization

### DIFF
--- a/tests/test_api/test_authorization.py
+++ b/tests/test_api/test_authorization.py
@@ -52,6 +52,20 @@ def mock_registry():
 class TestIsAuthorizedOrigin:
     """Tests for _is_authorized_origin helper function."""
 
+    def test_platform_default_origin_always_allowed(self, mock_registry):  # noqa: ARG002
+        """Platform default origin (osa-demo.pages.dev) should be allowed for all communities."""
+        # Exact match
+        assert _is_authorized_origin("https://osa-demo.pages.dev", "hed") is True
+        assert _is_authorized_origin("https://osa-demo.pages.dev", "bids") is True
+        assert _is_authorized_origin("https://osa-demo.pages.dev", "no-cors") is True
+
+    def test_platform_wildcard_origin_always_allowed(self, mock_registry):  # noqa: ARG002
+        """Platform wildcard origins (*.osa-demo.pages.dev) should be allowed for all communities."""
+        # Wildcard subdomains
+        assert _is_authorized_origin("https://develop.osa-demo.pages.dev", "hed") is True
+        assert _is_authorized_origin("https://preview-123.osa-demo.pages.dev", "bids") is True
+        assert _is_authorized_origin("https://feature-branch.osa-demo.pages.dev", "no-cors") is True
+
     def test_exact_origin_match(self, mock_registry):  # noqa: ARG002
         """Should return True for exact origin match."""
         assert _is_authorized_origin("https://hedtags.org", "hed") is True


### PR DESCRIPTION
## Summary

The platform's demo frontend (osa-demo.pages.dev) was being rejected with 403 errors because `_is_authorized_origin` only checked community-specific CORS origins, not the platform default origins.

## Problem

Requests from `https://develop.osa-demo.pages.dev` were returning:
```
403: API key required. Please provide your OpenRouter API key via the X-OpenRouter-Key header.
```

This happened because:
1. CORS middleware (in main.py) correctly allowed the request through
2. But `_is_authorized_origin()` in community.py only checked community-specific origins
3. The platform's demo origins were not in the HED community's config

## Solution

Added platform default origins to `_is_authorized_origin()` check:
- `https://osa-demo.pages.dev` (exact)
- `https://*.osa-demo.pages.dev` (wildcard for branch deploys)

These are now allowed for ALL communities by default, matching the CORS middleware behavior.

## Testing

- Added 2 new tests for platform default origin authorization
- All 791 tests passing
- 70% coverage maintained