### PR TITLE
chore: strip dev suffix for stable release 0.5.2

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.5.2.dev0"
-__version_info__ = (0, 5, 2, "dev")
+__version__ = "0.5.2"
+__version_info__ = (0, 5, 2)
 
 
 def get_version() -> str:


### PR DESCRIPTION
## Summary

Manual strip of `.dev` suffix to create stable release version `0.5.2`.

## Why Manual?

The `ensure-stable-version` workflow failed to push to main due to branch protection rules:
- Main requires changes through pull requests
- Required status checks must pass
- Workflow used `GITHUB_TOKEN` which cannot bypass these rules

## Changes

```diff
- __version__ = "0.5.2.dev0"
- __version_info__ = (0, 5, 2, "dev")
+ __version__ = "0.5.2"
+ __version_info__ = (0, 5, 2)
```

## Post-Merge Actions

After merging:
1. `tag-release` workflow will automatically:
   - Create tag `v0.5.2`
   - Create GitHub release with `--latest` flag
   
2. Production backend will auto-deploy

## Follow-up

Need to fix `ensure-stable-version` workflow to handle branch protection. Options:
- Use a PAT with bypass permissions
- Configure branch protection to allow github-actions[bot] bypass
- Keep manual process (this PR approach)

---

**Ready to merge immediately** - Single commit, simple version string change.