### PR TITLE
fix: ensure-stable-version creates PR instead of direct push

### DIFF
--- a/.github/workflows/ensure-stable-version.yml
+++ b/.github/workflows/ensure-stable-version.yml
@@ -8,12 +8,13 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   strip-dev-suffix:
     runs-on: ubuntu-latest
-    # Prevent infinite loop - only run for non-bot commits
-    if: github.actor != 'github-actions[bot]'
+    # Prevent infinite loop - only run for non-bot commits and non-strip-dev commits
+    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, 'strip dev suffix')
 
     steps:
       - name: Checkout code
@@ -55,8 +56,14 @@ jobs:
       - name: Create branch and commit
         if: steps.check_version.outputs.has_dev == 'true'
         id: commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="bot/strip-dev-suffix-${{ env.new_version }}"
+
+          # Delete remote branch if exists (from previous workflow run)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -72,11 +79,18 @@ jobs:
           BRANCH="${{ steps.commit.outputs.branch }}"
           git push -u origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore: strip dev suffix for stable release ${{ env.new_version }}" \
-            --body "Automated PR to strip \`.dev\` suffix from version on main branch.
+          # Check if PR already exists
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "✓ PR #$EXISTING_PR already exists for branch $BRANCH"
+            gh pr view "$EXISTING_PR" --json url --jq '.url'
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: strip dev suffix for stable release ${{ env.new_version }}" \
+              --body "Automated PR to strip \`.dev\` suffix from version on main branch.
 
           **Changes:**
           - \`${{ steps.check_version.outputs.version }}\` → \`${{ env.new_version }}\`
@@ -87,4 +101,5 @@ jobs:
           **Action required:**
           Please review and merge this PR to complete the release process. After merge, the \`tag-release\` workflow will automatically create the release tag."
 
-          echo "✅ Created PR from $BRANCH"
+            echo "✅ Created PR from $BRANCH"
+          fi


### PR DESCRIPTION
## Summary

Fixes the `ensure-stable-version` workflow failure that occurred when merging to main.

## Problem

The workflow failed with:
```
remote: error: GH013: Repository rule violations found for refs/heads/main
- Changes must be made through a pull request
- 3 of 3 required status checks are expected
```

**Root cause:** Branch protection rules prevent direct pushes to main, even from workflows with `contents: write` permissions.

## Solution

Updated workflow to **create a PR** instead of pushing directly:

1. Creates a branch: `bot/strip-dev-suffix-{version}`
2. Commits the version change to that branch
3. Creates a PR to main automatically using `gh pr create`
4. Maintainer reviews and merges the PR

## Benefits

✅ Respects branch protection rules  
✅ Maintains PR-based workflow for all main branch changes  
✅ No bypass permissions needed  
✅ Automated but auditable  
✅ Works with existing CI/CD setup  

## Changes

```yaml
# Before: Direct push (fails with branch protection)
git push

# After: Create PR (works with branch protection)
git checkout -b "bot/strip-dev-suffix-{version}"
git push -u origin "bot/strip-dev-suffix-{version}"
gh pr create --base main --head "bot/strip-dev-suffix-{version}" ...
```

## Testing

Will be tested when next `.dev` version is merged to main:
1. Workflow detects dev suffix
2. Creates PR automatically
3. Maintainer merges PR
4. `tag-release` workflow creates release

## Related

- PR #91: Manual fix for current 0.5.2 release (this workflow will handle future releases automatically)