### PR TITLE
fix: widget showing wrong community on demo page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -163,8 +163,8 @@
 <body>
   <div id="page-content"></div>
 
-  <!-- Load the OSA Chat Widget -->
-  <script src="osa-chat-widget.js"></script>
+  <!-- Load the OSA Chat Widget (no-auto-init: we init after loading community config) -->
+  <script src="osa-chat-widget.js" data-no-auto-init></script>
 
   <script>
     // Community configurations fetched from the API
@@ -417,8 +417,9 @@
       `;
       document.getElementById('page-content').innerHTML = html;
 
-      // Configure widget for this community
+      // Configure and initialize widget for this community
       OSAChatWidget.setConfig(community.widget);
+      OSAChatWidget.init();
     }
 
     // Load communities from API and then route

--- a/frontend/osa-chat-widget.js
+++ b/frontend/osa-chat-widget.js
@@ -2690,16 +2690,6 @@
     return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id);
   }
 
-  // Start when DOM is ready, deferred to allow setConfig calls before init
-  function scheduleInit() {
-    setTimeout(init, 0);
-  }
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', scheduleInit);
-  } else {
-    scheduleInit();
-  }
-
   // Expose configuration for customization
   window.OSAChatWidget = {
     setConfig: function(options) {
@@ -2717,6 +2707,34 @@
     },
     getConfig: function() {
       return { ...CONFIG };
+    },
+    // Manually initialize the widget (use with data-no-auto-init on the script tag)
+    init: function() {
+      if (!initialized) {
+        initialized = true;
+        init();
+      }
     }
   };
+
+  // Auto-init unless the script tag has data-no-auto-init attribute
+  let initialized = false;
+  const currentScript = document.currentScript;
+  const noAutoInit = currentScript && currentScript.hasAttribute('data-no-auto-init');
+
+  if (!noAutoInit) {
+    function scheduleInit() {
+      setTimeout(function() {
+        if (!initialized) {
+          initialized = true;
+          init();
+        }
+      }, 0);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', scheduleInit);
+    } else {
+      scheduleInit();
+    }
+  }
 })();

--- a/workers/osa-worker/index.js
+++ b/workers/osa-worker/index.js
@@ -171,7 +171,7 @@ function isAllowedOrigin(origin) {
   // Check exact matches
   if (allowedPatterns.includes(origin)) return true;
 
-  // Check subdomains
+  // Check subdomains (require https:// to prevent origin spoofing)
   if (origin.startsWith('https://') && origin.endsWith('.eeglab.org')) return true;
   if (origin.startsWith('https://') && origin.endsWith('.github.io')) return true;
   if (origin.startsWith('https://') && origin.endsWith('.hedtags.org')) return true;


### PR DESCRIPTION
## Summary

Fixes widget community mismatch on the demo site. The widget auto-initialized with HED defaults before the async `loadCommunities()` fetch completed, so visiting `/bids` showed the HED assistant instead of BIDS.

**Fix:** Added `data-no-auto-init` attribute support so the demo page defers widget initialization until the correct community config is loaded. Third-party embeds continue to auto-init as before.

## Changes

- `frontend/index.html` - Use `data-no-auto-init` on script tag, call `OSAChatWidget.init()` after `setConfig()`
- `frontend/osa-chat-widget.js` - Add `init()` public API and `data-no-auto-init` attribute support
- `workers/osa-worker/index.js` - Improve CORS subdomain check comment

## Test plan

- [ ] Verify demo.osc.earth/bids shows BIDS assistant (not HED)
- [ ] Verify demo.osc.earth/hed shows HED assistant
- [ ] Verify demo.osc.earth landing page shows no widget
- [ ] Verify third-party embeds (without data-no-auto-init) still auto-init

Closes #163