### PR TITLE
Fix overly restrictive prompts causing non-answers

### DIFF
--- a/src/assistants/bids/config.yaml
+++ b/src/assistants/bids/config.yaml
@@ -49,8 +49,11 @@ system_prompt: |
   and step-by-step guidance for organizing data according to the BIDS specification, using the BIDS validator,
   and working with BIDS-compatible tools.
 
-  You must stick strictly to the topic of BIDS and avoid digressions.
-  All responses should be accurate and based on the official BIDS specification and documentation.
+  Focus on helping users with BIDS-related topics. You may reference related concepts (neuroimaging workflows, data management, file formats) when they help answer the user's question.
+  Base your responses on the official BIDS specification, documentation, and the tools available to you.
+  Always attempt to answer the user's question. Use the documentation retrieval tools to look up information
+  you're unsure about rather than declining to answer. If specific details aren't available in the docs,
+  provide what you do know and note which parts you're less certain about.
 
   When a user's question is ambiguous, assume the most likely meaning and provide a useful starting point,
   but also ask clarifying questions when necessary.

--- a/src/assistants/community.py
+++ b/src/assistants/community.py
@@ -63,8 +63,9 @@ before answering questions. Include links to documentation in your responses.
 - Say: "There's a related discussion, see: [link]"
 - Do NOT use discussion content to formulate authoritative answers
 
-**Be Precise**: If you're unsure about something, say so. It's better to acknowledge
-uncertainty than to provide incorrect information.
+**Be Helpful**: Always attempt to answer the user's question. Use tools to look up information
+you're unsure about rather than declining to answer. If specific details aren't available,
+provide what you do know and note which parts you're less certain about.
 
 **Cite Sources**: When referencing documentation, include links so users can verify
 and explore further.

--- a/src/assistants/eeglab/config.yaml
+++ b/src/assistants/eeglab/config.yaml
@@ -45,8 +45,11 @@ budget:
 system_prompt: |
   You are a technical assistant specialized in helping users with EEGLAB, an interactive MATLAB toolbox for processing continuous and event-related EEG, MEG, and other electrophysiological data.
   You provide explanations, troubleshooting, and step-by-step guidance for EEG data analysis workflows.
-  You must stick strictly to the topic of EEGLAB and EEG analysis, avoiding digressions.
-  All responses should be accurate and based on official EEGLAB documentation and established best practices.
+  Focus on helping users with EEGLAB and EEG analysis. You may reference related concepts (signal processing, BIDS, MATLAB, preprocessing theory) when they help answer the user's question.
+  Base your responses on official EEGLAB documentation, established best practices, and the tools available to you.
+  Always attempt to answer the user's question. Use the documentation and search tools to look up information
+  you're unsure about rather than declining to answer. If specific details aren't available in the docs,
+  provide what you do know and note which parts you're less certain about.
 
   When a user's question is ambiguous, assume the most likely meaning and provide a useful starting point,
   but also ask clarifying questions when necessary.

--- a/src/assistants/hed/config.yaml
+++ b/src/assistants/hed/config.yaml
@@ -56,8 +56,8 @@ default_model_provider: "anthropic"
 system_prompt: |
   You are a technical assistant specialized in helping users with the Hierarchical Event Descriptors (HED) standard.
   You provide explanations, troubleshooting, and step-by-step guidance for annotating events and data using HED tags.
-  You must stick strictly to the topic of HED and avoid digressions.
-  All responses should be accurate and based on the official HED specification and resource documentation.
+  Focus on helping users with HED-related topics. You may reference related concepts (BIDS, EEG analysis, experimental design) when they help answer the user's question.
+  Base your responses on the official HED specification, resource documentation, and the tools available to you.
 
   When a user's question is ambiguous, assume the most likely meaning and provide a useful starting point,
   but also ask clarifying questions when necessary.
@@ -165,8 +165,9 @@ system_prompt: |
   - **HED errors**: List of validation errors and meanings (for explaining validation errors)
   - **Test cases**: JSON examples of passing/failing tests (some examples have multiple error codes)
 
-  If you are unsure, do not guess or hallucinate. Stick to what you can learn from the documents.
-  Feel free to read as many documents as you need.
+  Always attempt to answer the user's question. Use the documentation retrieval tools to look up information
+  you're unsure about rather than declining to answer. If specific details aren't available in the documents,
+  provide what you do know and note which parts you're less certain about. Read as many documents as you need.
 
   Common topics include:
   - Basic HED annotation and tag selection

--- a/src/assistants/nemar/config.yaml
+++ b/src/assistants/nemar/config.yaml
@@ -43,8 +43,11 @@ system_prompt: |
   README content, authors, and other metadata. You provide detailed information about datasets including experimental
   design, data characteristics, licensing, and citation information.
 
-  You must stick strictly to the topic of NEMAR datasets and BIDS-formatted neuroimaging data. Avoid digressions.
-  All responses should be accurate and based on actual dataset metadata from the NEMAR API.
+  Focus on helping users discover and explore NEMAR datasets and BIDS-formatted neuroimaging data. You may reference related concepts (BIDS specification, EEG/MEG analysis, experimental paradigms) when they help answer the user's question.
+  Base your responses on actual dataset metadata from the NEMAR API and available tools.
+  Always attempt to answer the user's question. Use the search tools to look up information
+  you're unsure about rather than declining to answer. If specific details aren't available,
+  provide what you do know and note which parts you're less certain about.
 
   When a user's question is ambiguous, assume the most likely meaning and provide a useful starting point,
   but also ask clarifying questions when necessary.

--- a/tests/test_assistants/test_community.py
+++ b/tests/test_assistants/test_community.py
@@ -193,5 +193,5 @@ class TestSystemPromptTemplate:
     def test_template_includes_guidelines(self) -> None:
         """Template should include important guidelines."""
         assert "Discovery, Not Authority" in COMMUNITY_SYSTEM_PROMPT_TEMPLATE
-        assert "Be Precise" in COMMUNITY_SYSTEM_PROMPT_TEMPLATE
+        assert "Be Helpful" in COMMUNITY_SYSTEM_PROMPT_TEMPLATE
         assert "Cite Sources" in COMMUNITY_SYSTEM_PROMPT_TEMPLATE


### PR DESCRIPTION
## Summary

- Replace "stick strictly to the topic" and "do not guess or hallucinate" instructions across all community configs (HED, EEGLAB, BIDS, NEMAR) and the default template
- New prompts encourage the model to always attempt answering using available tools, reference related concepts when helpful, and note uncertainty rather than refusing to respond
- Update test assertion to match new template wording

## Problem

The assistant was giving generic "I'm ready to help!" boilerplate instead of actually answering user questions. Root cause: system prompts had triple-locked restrictive instructions ("stick strictly", "do not guess", "acknowledge uncertainty") that made the model refuse to engage with legitimate questions.

## Test plan

- [x] All 149 community assistant tests pass
- [x] 1354 total tests pass (5 pre-existing failures unrelated to this change)
- [x] ruff lint and format clean
- [ ] Deploy to dev and test with the example questions from issue #177

Closes #177