### PR TITLE
Fix widget showing HED title for all communities

### DIFF
--- a/src/api/routers/community.py
+++ b/src/api/routers/community.py
@@ -166,9 +166,9 @@ class SessionInfo(BaseModel):
 class WidgetConfigResponse(BaseModel):
     """Widget display configuration returned to the frontend."""
 
-    title: str = Field(..., description="Widget header title")
+    title: str = Field(..., description="Widget header title", min_length=1)
     initial_message: str | None = Field(default=None, description="Greeting message on open")
-    placeholder: str = Field(default="Ask a question...", description="Input placeholder text")
+    placeholder: str = Field(..., description="Input placeholder text")
     suggested_questions: list[str] = Field(
         default_factory=list, description="Clickable suggestion buttons"
     )
@@ -1119,7 +1119,6 @@ def create_community_router(community_id: str) -> APIRouter:
         widget_cfg = (
             info.community_config.widget if info.community_config else None
         ) or WidgetConfig()
-        resolved = widget_cfg.resolve(info.name)
 
         return CommunityConfigResponse(
             id=info.id,
@@ -1127,12 +1126,7 @@ def create_community_router(community_id: str) -> APIRouter:
             description=info.description,
             default_model=default_model,
             default_model_provider=default_provider,
-            widget=WidgetConfigResponse(
-                title=resolved["title"],
-                initial_message=resolved["initial_message"],
-                placeholder=resolved["placeholder"],
-                suggested_questions=resolved["suggested_questions"],
-            ),
+            widget=WidgetConfigResponse(**widget_cfg.resolve(info.name)),
         )
 
     # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `widget` field to `CommunityConfigResponse` API endpoint (`GET /{community_id}`) returning title, placeholder, initial_message, and suggested_questions from the community YAML config
- Widget now fetches and applies community-specific display settings on load, only for fields not explicitly set by the embedder via `setConfig`
- Track which CONFIG keys were explicitly set by the embedder to avoid overwriting custom values with API defaults

Closes #190

## Test plan

- [x] All existing tests pass (374 community tests, 759 total excluding 2 pre-existing failures)
- [x] Pre-commit hooks pass (ruff lint/format)
- [ ] Verify on `demo.osc.earth/communities/nemar/widget-test` that title shows "NEMAR Assistant"
- [ ] Verify on nemar.org that widget shows "NEMAR Assistant" after deploy
- [ ] Verify HED widget still works correctly on `demo.osc.earth`
- [ ] Verify that explicit `title` in `setConfig` is not overwritten by API config