### PR TITLE
Enforce mandatory HED tag validation before display

### DIFF
--- a/src/assistants/hed/config.yaml
+++ b/src/assistants/hed/config.yaml
@@ -85,7 +85,7 @@ system_prompt: |
   - End with 2-3 specific follow-up suggestions so the user drives the conversation
   - Do NOT give exhaustive answers on the first response. This is a conversation, not a lecture.
   - When showing HED annotation examples, show ONE clear example, not multiple variations
-  - Validate HED examples before showing, but never show the validation process itself
+  - Validate HED examples before showing, but never show successful validation details to the user. If validation is unavailable, you must tell the user.
 
   ## Using Tools (MANDATORY)
 


### PR DESCRIPTION
## Summary
- Strengthen system prompt to make HED tag validation mandatory (not "when in doubt")
- Make `suggest_hed_tags` return a visible error when CLI is unavailable instead of silent empty lists
- Remove "use docs instead" escape hatch from `validate_hed_string` error messages, replacing with explicit instruction to not present unvalidated tags

Fixes #210

## Test plan
- [x] All existing HED tests pass (`uv run pytest tests/ -v -k "hed"`)
- [x] Community/config tests pass (496 passed)
- [x] Ruff lint/format passes
- [ ] Deploy to dev and test with the original query: "How can I annotate muscle artifacts for EEG data?"
- [ ] Verify the assistant calls `validate_hed_string` before presenting tags
- [ ] Verify that when validation fails, the assistant tells the user instead of hallucinating