### PR TITLE
Add warning for communities using shared platform key

### DIFF
--- a/src/api/routers/health.py
+++ b/src/api/routers/health.py
@@ -36,6 +36,11 @@ def compute_community_health(config: CommunityConfig) -> dict[str, Any]:
             )
     else:
         api_key_status = "using_platform"
+        warnings.append(
+            "No community-specific API key configured; using shared OSA platform key. "
+            "This is for demonstration only and is not sustainable. "
+            "Requires a dedicated API key and active maintainer."
+        )
 
     # Documentation sources
     doc_count = len(config.documentation) if config.documentation else 0


### PR DESCRIPTION
## Summary
- Communities without `openrouter_api_key_env_var` in their config.yaml (e.g., EEGLAB, NEMAR) were silently using the platform key with status "degraded" but no warning message
- Now all communities without a dedicated API key show a warning: "No community-specific API key configured; using shared OSA platform key..."
- This makes the dashboard display the orange warning banner for all communities using the platform key, not just HED and BIDS

Follow-up to PR #221 and #222.

## Test plan
- [x] `uv run pytest tests/test_api/test_health.py tests/test_api/test_community_router.py -v` -- 55 tests pass
- [x] Verify EEGLAB/NEMAR now return warnings in `/metrics/public` response