### PR TITLE
Add community-specific logos to chat widget

### DIFF
--- a/frontend/osa-chat-widget.js
+++ b/frontend/osa-chat-widget.js
@@ -1510,7 +1510,7 @@
           changed = true;
         }
         if (w.logo_url != null && !_userSetKeys.has('logo')) {
-          // Resolve relative logo URLs against the API endpoint
+          // Resolve path-only logo URLs (starting with '/') against the API endpoint
           if (w.logo_url.startsWith('/')) {
             CONFIG.logo = CONFIG.apiEndpoint + w.logo_url;
           } else {
@@ -1571,7 +1571,17 @@
     // Update avatar with community logo if available
     const avatar = container.querySelector('.osa-chat-avatar');
     if (avatar && CONFIG.logo) {
-      avatar.innerHTML = '<img src="' + escapeHtml(CONFIG.logo) + '" alt="' + escapeHtml(CONFIG.title) + '">';
+      const fallback = avatar.innerHTML;
+      const img = document.createElement('img');
+      img.src = CONFIG.logo;
+      img.alt = CONFIG.title;
+      img.onerror = function() {
+        console.warn('[OSA] Failed to load community logo:', CONFIG.logo);
+        avatar.innerHTML = fallback;
+        img.onerror = null;
+      };
+      avatar.innerHTML = '';
+      avatar.appendChild(img);
     }
 
     // Update loading label if currently loading

--- a/src/api/routers/communities.py
+++ b/src/api/routers/communities.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
-from src.api.routers.community import _find_logo_file
+from src.api.routers.community import convention_logo_url
 from src.assistants import registry
 from src.core.config.community import WidgetConfig
 
@@ -29,11 +29,7 @@ def list_communities() -> list[dict[str, Any]]:
             continue
 
         widget = config.widget or _DEFAULT_WIDGET
-
-        # Convention-based logo detection
-        convention_logo = None
-        if not widget.logo_url and _find_logo_file(config.id):
-            convention_logo = f"/{config.id}/logo"
+        conv_logo = convention_logo_url(config.id, widget)
 
         communities.append(
             {
@@ -41,7 +37,7 @@ def list_communities() -> list[dict[str, Any]]:
                 "name": config.name,
                 "description": config.description,
                 "status": config.status,
-                "widget": widget.resolve(config.name, logo_url=convention_logo),
+                "widget": widget.resolve(config.name, logo_url=conv_logo),
                 "links": config.links.resolve() if config.links else None,
             }
         )

--- a/src/core/config/community.py
+++ b/src/core/config/community.py
@@ -669,10 +669,25 @@ class WidgetConfig(BaseModel):
     logo_url: str | None = Field(default=None, max_length=500)
     """URL to a custom logo/icon image for the widget header avatar.
 
-    Accepts any valid image URL (PNG, SVG, etc.). When not set, the API
-    auto-detects a logo.png or logo.svg file in the community's folder.
-    Falls back to a default brain icon in the widget if no logo is found.
+    Must be an HTTP(S) URL or a path starting with ``/``.  When not set,
+    the API auto-detects a ``logo.*`` file (SVG, PNG, JPG, JPEG, WEBP)
+    in the community's folder.  Falls back to a default brain icon in
+    the widget if no logo is found.
     """
+
+    @field_validator("logo_url", mode="before")
+    @classmethod
+    def validate_logo_url(cls, v: str | None) -> str | None:
+        """Ensure logo_url uses a safe scheme (http, https, or relative path)."""
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return None
+        if not (v.startswith("http://") or v.startswith("https://") or v.startswith("/")):
+            msg = "logo_url must use http://, https://, or be a path starting with '/'"
+            raise ValueError(msg)
+        return v
 
     @field_validator("title", "initial_message", "placeholder", mode="before")
     @classmethod
@@ -698,8 +713,8 @@ class WidgetConfig(BaseModel):
 
         Args:
             community_name: Display name used as fallback for title.
-            logo_url: Override logo URL (e.g. from convention-based detection).
-                      The explicit ``self.logo_url`` field takes precedence.
+            logo_url: Fallback logo URL (e.g. from convention-based detection).
+                      Only used when ``self.logo_url`` is not set.
         """
         return {
             "title": self.title or community_name or "Assistant",


### PR DESCRIPTION
## Summary

- Add `logo_url` field to `WidgetConfig` schema and API response
- Add `GET /{community_id}/logo` endpoint to serve logo files from community folders
- Auto-detect convention-based logo files (`logo.png`, `logo.svg`, etc.) in `src/assistants/{id}/`
- Update widget JS to render `<img>` avatar when logo URL is available, with proper CSS scaling
- Three-tier precedence: widget `setConfig()` > YAML `logo_url` > convention file > brain icon fallback

Closes #224

## Test plan

- [x] All 1450 existing tests pass (485 config/community/widget tests specifically)
- [x] Linting passes (ruff check + format)
- [ ] Manual: drop a `logo.png` in a community folder, verify API returns `logo_url` and widget renders it
- [ ] Manual: set `widget.logo_url` in YAML, verify it takes precedence
- [ ] Manual: use `setConfig({ logo: 'url' })`, verify embedder override works
- [ ] Manual: community with no logo still shows brain icon