### PR TITLE
Remove CORS origins for MNE and FieldTrip

### DIFF
--- a/src/assistants/fieldtrip/config.yaml
+++ b/src/assistants/fieldtrip/config.yaml
@@ -28,9 +28,10 @@ widget:
     - How do I do beamforming source analysis?
     - What data formats does FieldTrip support?
 
-cors_origins:
-  - https://www.fieldtriptoolbox.org
-  - https://fieldtriptoolbox.org
+# TODO: FieldTrip maintainers to submit PR adding CORS origins for fieldtriptoolbox.org
+# cors_origins:
+#   - https://www.fieldtriptoolbox.org
+#   - https://fieldtriptoolbox.org
 
 # Budget limits for cost management
 budget:

--- a/src/assistants/mne/config.yaml
+++ b/src/assistants/mne/config.yaml
@@ -28,9 +28,10 @@ widget:
     - How do I perform source localization?
     - How do I do time-frequency analysis?
 
-cors_origins:
-  - https://mne.tools
-  - https://*.mne.tools
+# TODO: MNE maintainers to submit PR adding CORS origins for mne.tools
+# cors_origins:
+#   - https://mne.tools
+#   - https://*.mne.tools
 
 # Budget limits for cost management
 budget:


### PR DESCRIPTION
## Summary
- Remove CORS origins for MNE (`mne.tools`) and FieldTrip (`fieldtriptoolbox.org`) since neither community has been onboarded by their maintainers yet
- Both communities are only hosted on our demo page (`demo.osc.earth` / `develop-demo.osc.earth`)
- Left TODO comments for maintainers to submit PRs adding CORS registration when ready

## Test plan
- [x] Config YAML validates (no structural changes, just commented out `cors_origins`)
- [x] Communities still accessible via demo page (no CORS needed for same-origin)