### PR TITLE
Switch Claude workflow jobs to OAuth token auth

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,10 +49,6 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    env:
-      # Force all models to Haiku 4.5 for cost efficiency
-      ANTHROPIC_DEFAULT_SONNET_MODEL: claude-haiku-4-5-20251001
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,9 +59,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
+          claude_args: |
+            --model claude-haiku-4-5-20251001
 
   # Check new issues for duplicates
   deduplicate-issue:
@@ -76,10 +74,6 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    env:
-      # Force all models to Haiku 4.5 for cost efficiency
-      ANTHROPIC_DEFAULT_SONNET_MODEL: claude-haiku-4-5-20251001
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,7 +119,8 @@ jobs:
 
             Be thorough but efficient. Focus on finding true duplicates, not just similar issues.
 
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           claude_args: |
-            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"
+            --model claude-haiku-4-5-20251001 --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"


### PR DESCRIPTION
## Summary

- Switch `triage-issue` and `deduplicate-issue` jobs from `anthropic_api_key` to `claude_code_oauth_token`, so all three jobs in `claude.yml` use the subscription token consistently
- Replace `ANTHROPIC_DEFAULT_*_MODEL` env vars with `--model claude-haiku-4-5-20251001` via `claude_args` (env vars are stripped by claude-code-action when using OAuth auth, causing SDK crash)
- Add `allowed_non_write_users: "*"` to `deduplicate-issue` (was missing, causing permission failures for issues opened by external contributors)

## Context

The Feb 11 failed runs showed that when using OAuth token auth, the action ignores `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_HAIKU_MODEL` env vars (they resolve to empty), falls back to full Sonnet, and then the Claude Code process crashes with `SDK execution error`. The supported way to set the model with OAuth is via `claude_args: --model`.

## Test plan

- [x] Verify all jobs reference `claude_code_oauth_token` consistently
- [ ] Open a test issue to trigger `triage-issue` and `deduplicate-issue` jobs
- [ ] Verify both jobs complete successfully with Haiku model