### PR TITLE
Fix duplicate review runs for same-repo PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,10 +10,13 @@ on:
 
 jobs:
   claude-review:
-    # Only review PRs from external contributors, skip duplicates
+    # Only review PRs from external contributors, skip duplicates:
+    # - pull_request for same-repo branches (has secrets access)
+    # - pull_request_target for fork PRs only (provides secrets access that pull_request lacks for forks)
     if: |
       github.event.pull_request.user.login != 'neuromechanist' &&
-      !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+      !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) &&
+      !(github.event_name == 'pull_request_target' && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add missing condition to prevent `pull_request_target` from firing for same-repo PRs
- Without this fix, PRs by non-neuromechanist contributors from same-repo branches would trigger two review runs (one from `pull_request`, one from `pull_request_target`)
- Fork PRs still correctly use `pull_request_target` only (which provides secrets access)

## Test plan

- [ ] Verify review triggers exactly once when a non-neuromechanist user opens a same-repo PR
- [ ] Verify review triggers exactly once for fork PRs via `pull_request_target`
- [x] Verify neuromechanist PRs are still skipped