### PR TITLE
Improve widget footer: AI disclaimer and compact layout

### DIFF
--- a/frontend/osa-chat-widget.js
+++ b/frontend/osa-chat-widget.js
@@ -701,9 +701,6 @@
       40% { transform: scale(1); }
     }
 
-    .osa-chat-footer {
-      display: none;
-    }
 
     .osa-turnstile-container {
       padding: 12px 16px;
@@ -754,12 +751,8 @@
       font-size: 10px;
       text-align: center;
       border-top: 1px solid var(--osa-border);
-    }
-
-    .osa-footer-separator {
-      color: var(--osa-text-light);
-      opacity: 0.5;
-      flex-shrink: 0;
+      color: var(--osa-disclaimer-color, #9a3412);
+      background: var(--osa-disclaimer-bg, #fff7ed);
     }
 
     .osa-combined-footer {
@@ -778,6 +771,13 @@
       align-items: center;
       gap: 5px;
       flex-shrink: 0;
+    }
+
+    .osa-combined-footer .osa-page-context-toggle::after {
+      content: '|';
+      color: var(--osa-text-light);
+      opacity: 0.5;
+      margin-left: 3px;
     }
 
     .osa-combined-footer input[type="checkbox"] {
@@ -1581,6 +1581,15 @@
       container.style.setProperty('--osa-primary-dark', darker);
     }
 
+    // Apply disclaimer colors if configured (must be valid CSS color: hex, named, rgb, hsl)
+    const cssColorPattern = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]+|rgba?\([^)]+\)|hsla?\([^)]+\))$/;
+    if (CONFIG.disclaimerColor && cssColorPattern.test(CONFIG.disclaimerColor.trim())) {
+      container.style.setProperty('--osa-disclaimer-color', CONFIG.disclaimerColor.trim());
+    }
+    if (CONFIG.disclaimerBackground && cssColorPattern.test(CONFIG.disclaimerBackground.trim())) {
+      container.style.setProperty('--osa-disclaimer-bg', CONFIG.disclaimerBackground.trim());
+    }
+
     // Update header title
     const titleEl = container.querySelector('.osa-chat-title');
     if (titleEl) {
@@ -1948,13 +1957,12 @@
             ${ICONS.send}
           </button>
         </div>
-        <div class="osa-ai-disclaimer" style="display: ${CONFIG.disclaimerEnabled ? 'block' : 'none'}; color: ${CONFIG.disclaimerColor}; background: ${CONFIG.disclaimerBackground};">${escapeHtml(CONFIG.disclaimerText)}</div>
+        <div class="osa-ai-disclaimer" style="display: ${CONFIG.disclaimerEnabled ? 'block' : 'none'}">${escapeHtml(CONFIG.disclaimerText || '')}</div>
         <div class="osa-combined-footer">
           <div class="osa-page-context-toggle" style="display: ${CONFIG.allowPageContext ? 'flex' : 'none'}">
             <input type="checkbox" id="osa-page-context-checkbox" ${pageContextEnabled ? 'checked' : ''} />
             <label for="osa-page-context-checkbox">${escapeHtml(CONFIG.pageContextLabel)}</label>
           </div>
-          <span class="osa-footer-separator" style="display: ${CONFIG.allowPageContext ? 'inline' : 'none'}">|</span>
           <div class="osa-footer-powered">
             Powered by <a href="${escapeHtml(CONFIG.repoUrl)}" target="_blank" rel="noopener noreferrer">OSA</a><span class="osa-version"></span>
           </div>


### PR DESCRIPTION
## Summary
- Add configurable AI disclaimer above the footer: "This is a multi-agent AI assistant and may make mistakes. Please verify responses." (faded orange background)
- Merge the two separate footer lines (page context checkbox + powered by) into a single compact row with pipe separator
- Left side: checkbox for "Share page URL to help answer questions"
- Right side: "Powered by [OSA](https://osc.earth/osa/) v0.7.1 (71a2511)" with OSA hyperlinked to website
- All disclaimer options configurable: `disclaimerEnabled`, `disclaimerText`, `disclaimerColor`, `disclaimerBackground`
- Color values validated with CSS color pattern before applying (matches existing themeColor approach)

Closes #245

## Test plan
- [x] Verify AI disclaimer renders above the footer with orange background
- [x] Verify combined footer shows checkbox on left, powered-by on right, pipe separator between
- [x] Verify "OSA" link opens osc.earth/osa in new tab
- [x] Verify version and commit hash still display correctly
- [x] Verify page context checkbox toggle still works
- [x] Verify layout correct when allowPageContext is false (checkbox and separator hidden)
- [x] Verify disclaimer hidden when disclaimerEnabled is false
- [x] Verify invalid color values fall back to defaults (CSS custom property fallback)