### PR TITLE
Fix CI for external contributor PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,14 +9,12 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-  claude-review:
-    # Only review PRs from external contributors, skip duplicates:
-    # - pull_request for same-repo branches (has secrets access)
-    # - pull_request_target for fork PRs only (provides secrets access that pull_request lacks for forks)
+  # Same-repo PRs: full review with push capabilities
+  claude-review-internal:
     if: |
-      github.event.pull_request.user.login != 'neuromechanist' &&
-      !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) &&
-      !(github.event_name == 'pull_request_target' && !github.event.pull_request.head.repo.fork)
+      github.event_name == 'pull_request' &&
+      !github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.user.login != 'neuromechanist'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,8 +27,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # For fork PRs via pull_request_target, check out the PR head safely
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Review and fix PR
@@ -53,4 +49,45 @@ jobs:
             Keep commit messages concise (<50 chars, no emojis).
 
             After making fixes, leave a PR comment summarizing what was found and what was fixed.
-            If you cannot push to the PR branch (e.g., fork PRs), leave detailed review comments instead.
+
+  # Fork PRs: review-only with comments (cannot push to fork branches)
+  claude-review-fork:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.user.login != 'neuromechanist'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout PR head (read-only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Review PR (comments only)
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            Review this pull request thoroughly. This is a fork PR, so you cannot push commits.
+            Leave detailed review comments directly on the PR for each issue found.
+
+            For each issue:
+            1. Classify severity: critical, important, or suggestion
+            2. Leave an inline review comment on the relevant code
+            3. Explain the issue and suggest the fix
+
+            Follow the project's code style (ruff formatting, type hints, no mocks in tests).
+            Do not suggest adding AI attribution.
+
+            After reviewing, leave a summary PR comment listing all issues found.

--- a/.github/workflows/sync-worker-cors.yml
+++ b/.github/workflows/sync-worker-cors.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CI_ADMIN_TOKEN }}
+          # CI_ADMIN_TOKEN for push events (needs write access to commit);
+          # falls back to github.token for PRs (read-only, no secrets on forks)
+          token: ${{ secrets.CI_ADMIN_TOKEN || github.token }}
           fetch-depth: 0  # Fetch full history so git diff works
 
       - name: Set up Python

--- a/tests/test_assistants/test_community_yaml_generic.py
+++ b/tests/test_assistants/test_community_yaml_generic.py
@@ -96,12 +96,13 @@ class TestCommunityYAMLConfiguration:
                 )
 
     @pytest.mark.slow
+    @pytest.mark.network
     def test_documentation_urls_accessible(self, community_id):
         """All documentation source URLs should return HTTP 200.
 
-        This test makes real HTTP requests and is marked as 'slow'.
-        Slow tests are included by default in test runs.
-        To skip slow tests: pytest -m "not slow"
+        This test makes real HTTP requests and is marked as 'slow' and 'network'.
+        Network tests are excluded from CI by default.
+        To run: pytest -m "network"
         """
         from src.assistants import registry
 
@@ -141,12 +142,13 @@ class TestCommunityYAMLConfiguration:
             assert parts[1], f"{community_id}: Missing repo name in {repo}"
 
     @pytest.mark.slow
+    @pytest.mark.network
     def test_github_repos_exist(self, community_id):
         """All GitHub repos should exist and be accessible.
 
-        This test makes real GitHub API requests and is marked as 'slow'.
-        Slow tests are included by default in test runs.
-        To skip slow tests: pytest -m "not slow"
+        This test makes real GitHub API requests and is marked as 'slow' and 'network'.
+        Network tests are excluded from CI by default.
+        To run: pytest -m "network"
         """
         from src.assistants import registry
 

--- a/tests/test_tools/test_nemar_tools.py
+++ b/tests/test_tools/test_nemar_tools.py
@@ -121,6 +121,7 @@ class TestMatches:
         assert _matches(sample_dataset, "visual", "MEG", "attention", None, 10) is False
 
 
+@pytest.mark.network
 class TestFetchAllDatasets:
     """Tests for the NEMAR API fetch function."""
 
@@ -147,6 +148,7 @@ class TestFetchAllDatasets:
         assert len(datasets) < 5000
 
 
+@pytest.mark.network
 class TestSearchNemarDatasets:
     """Tests for the search_nemar_datasets tool against the live API."""
 
@@ -210,6 +212,7 @@ class TestSearchNemarDatasets:
 class TestGetNemarDatasetDetails:
     """Tests for the get_nemar_dataset_details tool against the live API."""
 
+    @pytest.mark.network
     def test_get_known_dataset(self):
         """Test retrieving a known dataset (ds000248 - MNE sample data)."""
         result = get_nemar_dataset_details.invoke({"dataset_id": "ds000248"})
@@ -219,6 +222,7 @@ class TestGetNemarDatasetDetails:
         assert "nemar.org/dataexplorer/detail" in result
         assert "Data Characteristics" in result
 
+    @pytest.mark.network
     def test_get_dataset_has_metadata(self):
         """Test that retrieved dataset contains expected metadata sections."""
         result = get_nemar_dataset_details.invoke({"dataset_id": "ds000248"})
@@ -228,6 +232,7 @@ class TestGetNemarDatasetDetails:
         assert "Participants:" in result
         assert "HED annotations:" in result
 
+    @pytest.mark.network
     def test_get_dataset_has_links(self):
         """Test that dataset details include OpenNeuro and NEMAR links."""
         result = get_nemar_dataset_details.invoke({"dataset_id": "ds000248"})
@@ -235,11 +240,13 @@ class TestGetNemarDatasetDetails:
         assert "https://openneuro.org/datasets/ds000248" in result
         assert "https://nemar.org/dataexplorer/detail?dataset_id=ds000248" in result
 
+    @pytest.mark.network
     def test_get_nonexistent_dataset(self):
         """Test that a nonexistent dataset returns a clear message."""
         result = get_nemar_dataset_details.invoke({"dataset_id": "ds999999"})
         assert "not found" in result
 
+    @pytest.mark.network
     def test_get_dataset_with_hed(self):
         """Test retrieving a dataset known to have HED annotations."""
         # ds002578 has HED annotations
@@ -263,6 +270,7 @@ class TestGetNemarDatasetDetails:
         assert "Invalid dataset ID" in result
 
 
+@pytest.mark.network
 class TestCaching:
     """Tests for the TTL cache on _fetch_all_datasets."""
 


### PR DESCRIPTION
## Summary

- Mark NEMAR API tests and doc URL accessibility tests with `@pytest.mark.network` so they are excluded from PR CI (CI already uses `-m "not network"`)
- Split `claude-code-review.yml` into two jobs: internal PRs (can push fixes) and fork PRs (comment-only review) to fix permission errors on fork contributions
- Use `github.token` fallback in `sync-worker-cors.yml` for PR events where `CI_ADMIN_TOKEN` is unavailable (fork PRs)

## Context

PR #262 (first organic community contribution) exposed these issues: all CI checks failed despite the PR content (a single config.yaml) being valid. The failures were from unrelated NEMAR API 403s, claude-code-action write permission errors on forks, and missing tokens.

## Test plan

- [x] `uv run pytest -m "not network"` passes locally (1626 passed, 38 deselected)
- [x] NEMAR network tests properly deselected (19 tests)
- [x] Generic config URL/GitHub tests properly deselected (12 tests)
- [x] Pre-commit hooks pass (ruff, yaml check, etc.)
- [ ] CI passes on this PR
- [ ] Re-run CI on PR #262 to verify it passes

Closes #263