### PR TITLE
Fix fork PR CI permissions, bump to 0.8.1.dev0

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,14 +58,14 @@ jobs:
       github.event.pull_request.user.login != 'neuromechanist'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: read
       id-token: write
       actions: read
 
     steps:
-      - name: Checkout PR head (read-only)
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -76,6 +76,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/sync-worker-cors.yml
+++ b/.github/workflows/sync-worker-cors.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.check_changes.outputs.changed == 'true' && github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.8.0"
-__version_info__ = (0, 8, 0)
+__version__ = "0.8.1.dev0"
+__version_info__ = (0, 8, 1, "dev")
 
 
 def get_version() -> str:


### PR DESCRIPTION
## Summary

- Add `contents: write` and `allowed_non_write_users: "*"` to `claude-review-fork` job so it can run for external contributors
- Add `continue-on-error: true` to CORS PR comment step (fork PRs can't post comments; the actual CORS sync happens on merge, not on PR)
- Bump version to `0.8.1.dev0` for develop

## Context

PR #262 (metabci) was merged but claude-review-fork and sync-cors still failed on the ready-for-review event due to permission issues. This also needs to land on main for `pull_request_target` to pick it up.

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] After merge to develop, merge develop to main for `pull_request_target` workflow pickup
- [ ] TestPyPI publish triggers for 0.8.1.dev0