### PR TITLE
fix: raise docstring snippet cap and add full-fetch tool (#276)

### DIFF
--- a/src/knowledge/search.py
+++ b/src/knowledge/search.py
@@ -511,7 +511,10 @@ def search_docstrings(
             params[0] = safe_query
 
             for idx, row in enumerate(conn.execute(sql, params)):
-                snippet = _make_snippet(row["docstring"])
+                # Docstrings encode their value in Outputs/Parameters/Examples
+                # sections that often start past char 1000. Use a larger cap so
+                # the LLM sees the structured sections, not just the summary.
+                snippet = _make_snippet(row["docstring"], max_length=1500)
 
                 # Build GitHub URL to the specific line
                 file_path = row["file_path"] or ""
@@ -563,6 +566,84 @@ def search_docstrings(
     except sqlite3.Error as e:
         # Other database errors - still raise for debugging
         logger.warning("Database error during docstring search '%s': %s", query, e)
+        raise
+
+    return results
+
+
+def get_full_docstring(
+    symbol_name: str,
+    project: str = "hed",
+    language: str | None = None,
+    repo: str | None = None,
+) -> list[SearchResult]:
+    """Return the complete docstring(s) for a symbol, without truncation.
+
+    Used by the LLM as a follow-up after search_docstrings when the snippet
+    is insufficient to answer the user's question (e.g. they ask about
+    specific outputs, parameters, or examples that fall past the snippet cap).
+
+    Args:
+        symbol_name: Exact symbol name to look up (case-insensitive).
+        project: Assistant/project name for database isolation. Defaults to 'hed'.
+        language: Filter by 'matlab' or 'python'.
+        repo: Filter by repository name.
+
+    Returns:
+        List of SearchResult objects with `snippet` containing the full
+        docstring (no truncation). Empty list if no exact match.
+    """
+    sql = """
+        SELECT symbol_name, docstring, file_path, repo,
+               language, symbol_type, line_number, branch
+        FROM docstrings
+        WHERE LOWER(symbol_name) = LOWER(?)
+    """
+    params: list[str] = [symbol_name]
+
+    if language:
+        sql += " AND language = ?"
+        params.append(language)
+    if repo:
+        sql += " AND repo = ?"
+        params.append(repo)
+
+    results: list[SearchResult] = []
+    try:
+        with get_connection(project) as conn:
+            for row in conn.execute(sql, params):
+                file_path = row["file_path"] or ""
+                repo_name = row["repo"]
+                line_number = row["line_number"]
+                branch = row["branch"] or "main"
+
+                github_url = f"https://github.com/{repo_name}/blob/{branch}/{file_path}"
+                if line_number:
+                    github_url += f"#L{line_number}"
+
+                title = f"{row['symbol_name']} ({row['symbol_type']}) - {file_path}"
+
+                results.append(
+                    SearchResult(
+                        title=title,
+                        url=github_url,
+                        snippet=row["docstring"] or "",
+                        source=row["language"],
+                        item_type=row["symbol_type"],
+                        status="documented",
+                        created_at="",
+                    )
+                )
+    except sqlite3.OperationalError as e:
+        logger.error(
+            "Database operational error fetching full docstring: %s",
+            e,
+            exc_info=True,
+            extra={"symbol_name": symbol_name, "project": project},
+        )
+        raise
+    except sqlite3.Error as e:
+        logger.warning("Database error fetching full docstring '%s': %s", symbol_name, e)
         raise
 
     return results

--- a/src/knowledge/search.py
+++ b/src/knowledge/search.py
@@ -28,6 +28,21 @@ def _make_snippet(text: str | None, max_length: int = 200) -> str:
     return snippet
 
 
+# Docstring search results need enough room to include the structured
+# sections (Usage / Parameters / Outputs / Examples) that follow the
+# opening summary. The default `_make_snippet` cap of 200 chars truncated
+# inside the summary sentence and caused issue #276. Bumping the cap is
+# a deliberate tradeoff against token budget: 1500 chars * default
+# limit=5 = ~7.5K chars per call, well within agent context.
+DOCSTRING_SNIPPET_MAX_LENGTH = 1500
+
+# Hard cap on the number of full-docstring rows returned by
+# `get_full_docstring`. Symbols like "init" or "plot" can match many
+# rows across files/repos; without a cap a single tool call could
+# evict useful conversation history.
+FULL_DOCSTRING_DEFAULT_LIMIT = 5
+
+
 def _normalize_title_for_dedup(title: str) -> set[str]:
     """Normalize a paper title to a set of words for deduplication.
 
@@ -511,10 +526,7 @@ def search_docstrings(
             params[0] = safe_query
 
             for idx, row in enumerate(conn.execute(sql, params)):
-                # Docstrings encode their value in Outputs/Parameters/Examples
-                # sections that often start past char 1000. Use a larger cap so
-                # the LLM sees the structured sections, not just the summary.
-                snippet = _make_snippet(row["docstring"], max_length=1500)
+                snippet = _make_snippet(row["docstring"], max_length=DOCSTRING_SNIPPET_MAX_LENGTH)
 
                 # Build GitHub URL to the specific line
                 file_path = row["file_path"] or ""
@@ -576,22 +588,31 @@ def get_full_docstring(
     project: str = "hed",
     language: str | None = None,
     repo: str | None = None,
+    limit: int = FULL_DOCSTRING_DEFAULT_LIMIT,
 ) -> list[SearchResult]:
-    """Return the complete docstring(s) for a symbol, without truncation.
+    """Return the stored docstring(s) for a symbol, in full.
 
     Used by the LLM as a follow-up after search_docstrings when the snippet
     is insufficient to answer the user's question (e.g. they ask about
     specific outputs, parameters, or examples that fall past the snippet cap).
 
     Args:
-        symbol_name: Exact symbol name to look up (case-insensitive).
+        symbol_name: Symbol to look up. Matched via LOWER() on both sides,
+            so the lookup is case-insensitive. Note that this is non-sargable
+            and forces a table scan; if the docstrings table grows much
+            larger, add a functional index on LOWER(symbol_name).
         project: Assistant/project name for database isolation. Defaults to 'hed'.
         language: Filter by 'matlab' or 'python'.
         repo: Filter by repository name.
+        limit: Max rows to return. Defaults to FULL_DOCSTRING_DEFAULT_LIMIT.
+            Symbols like "init" or "plot" can match many rows across
+            files/repos; the cap prevents an unbounded payload.
 
     Returns:
-        List of SearchResult objects with `snippet` containing the full
-        docstring (no truncation). Empty list if no exact match.
+        List of SearchResult objects with `snippet` containing the stored
+        docstring. The storage layer caps each docstring at 10K chars at
+        ingest (see `upsert_docstring`), so "full" means "up to 10K chars".
+        Empty list if no matching symbol (case-insensitive equality).
     """
     sql = """
         SELECT symbol_name, docstring, file_path, repo,
@@ -599,7 +620,7 @@ def get_full_docstring(
         FROM docstrings
         WHERE LOWER(symbol_name) = LOWER(?)
     """
-    params: list[str] = [symbol_name]
+    params: list[str | int] = [symbol_name]
 
     if language:
         sql += " AND language = ?"
@@ -607,6 +628,11 @@ def get_full_docstring(
     if repo:
         sql += " AND repo = ?"
         params.append(repo)
+
+    # Deterministic order across runs so the LLM sees a stable view when
+    # multiple files/repos define the same symbol name.
+    sql += " ORDER BY repo, file_path LIMIT ?"
+    params.append(limit)
 
     results: list[SearchResult] = []
     try:
@@ -623,11 +649,28 @@ def get_full_docstring(
 
                 title = f"{row['symbol_name']} ({row['symbol_type']}) - {file_path}"
 
+                docstring = row["docstring"]
+                if not docstring:
+                    # NULL/empty stored docstring would render as a hit with
+                    # no body and mislead the LLM. Log and skip so the
+                    # caller sees the missing-data state rather than a
+                    # phantom result.
+                    logger.warning(
+                        "Empty stored docstring for symbol",
+                        extra={
+                            "symbol_name": row["symbol_name"],
+                            "file_path": file_path,
+                            "repo": repo_name,
+                            "project": project,
+                        },
+                    )
+                    continue
+
                 results.append(
                     SearchResult(
                         title=title,
                         url=github_url,
-                        snippet=row["docstring"] or "",
+                        snippet=docstring,
                         source=row["language"],
                         item_type=row["symbol_type"],
                         status="documented",

--- a/src/tools/knowledge.py
+++ b/src/tools/knowledge.py
@@ -305,17 +305,23 @@ def create_search_docstrings_tool(
             return f"No code documentation found for '{query}'{lang_str}."
 
         lines = [f"Code documentation in {community_name}:\n"]
+        # `_make_snippet` appends "..." iff it truncated. Only nudge the LLM
+        # toward the full-fetch tool when at least one result was actually
+        # truncated; otherwise the hint encourages a wasteful follow-up.
+        any_truncated = any(r.snippet.endswith("...") for r in results)
         for r in results:
             lines.append(f"- {r.title}")
             lines.append(f"  [View source on GitHub]({r.url})")
             if r.snippet:
                 lines.append(f"  Documentation: {r.snippet}")
             lines.append("")
-        lines.append(
-            f"If a snippet appears truncated and the user is asking about specific "
-            f"outputs, parameters, or examples, call get_{community_id}_full_docstring "
-            f"with the symbol_name to retrieve the complete docstring."
-        )
+        if any_truncated:
+            lines.append(
+                f"One or more snippets were truncated. If the user is asking about "
+                f"specific outputs, parameters, or examples, call "
+                f"get_{community_id}_full_docstring with the symbol_name to "
+                f"retrieve the stored docstring in full."
+            )
 
         return "\n".join(lines)
 
@@ -323,8 +329,9 @@ def create_search_docstrings_tool(
         f"Search {community_name} code documentation (docstrings from functions, classes, scripts).{lang_help} "
         "Use this to find how specific functions work, what parameters they accept, "
         "and see usage examples. Results include direct links to source code on GitHub. "
-        "If the returned snippet is truncated and you need full details about outputs, "
-        f"parameters, or examples, follow up with get_{community_id}_full_docstring."
+        "If the returned snippet is truncated (marked with `...`) and you need full "
+        "details about outputs, parameters, or examples, follow up with "
+        f"get_{community_id}_full_docstring."
     )
 
     return StructuredTool.from_function(
@@ -355,7 +362,7 @@ def create_get_full_docstring_tool(
     """
 
     def get_full_docstring_impl(symbol_name: str) -> str:
-        """Fetch the complete docstring for a symbol."""
+        """Fetch the stored docstring for a symbol (in full, up to 10K chars)."""
         if not _check_db_exists(community_id):
             return (
                 f"Knowledge database for {community_name} not initialized. "
@@ -365,7 +372,12 @@ def create_get_full_docstring_tool(
         try:
             results = get_full_docstring(symbol_name, project=community_id, language=language)
         except sqlite3.OperationalError as e:
-            if "no such table" in str(e):
+            # Case-insensitive match: SQLite phrasing has varied across
+            # versions/drivers (e.g. "no such table: docstrings" vs
+            # "No such table"). Lowercase before matching so a
+            # future capitalization shift can't silently break the
+            # friendly path and surface as a 500 to the user.
+            if "no such table" in str(e).lower():
                 logger.warning(
                     "Docstrings table not initialized for %s",
                     community_id,
@@ -375,13 +387,26 @@ def create_get_full_docstring_tool(
                     f"Knowledge database for {community_name} not initialized. "
                     f"Run 'osa sync docstrings --community {community_id}' to populate it."
                 )
+            logger.error(
+                "Database operational error in get_full_docstring tool: %s",
+                e,
+                exc_info=True,
+                extra={"symbol_name": symbol_name, "community": community_id},
+            )
+            raise
+        except sqlite3.Error as e:
+            logger.warning(
+                "Database error in get_full_docstring tool: %s",
+                e,
+                extra={"symbol_name": symbol_name, "community": community_id},
+            )
             raise
 
         if not results:
             return (
                 f"No docstring found for symbol '{symbol_name}' in {community_name}. "
-                "Try search_{community_id}_code_docs first to find the correct symbol name."
-            ).format(community_id=community_id)
+                f"Try search_{community_id}_code_docs first to find the correct symbol name."
+            )
 
         lines = [f"Full docstring(s) for '{symbol_name}' in {community_name}:\n"]
         for r in results:
@@ -394,10 +419,13 @@ def create_get_full_docstring_tool(
         return "\n".join(lines)
 
     description = (
-        f"Fetch the COMPLETE docstring for a specific symbol in {community_name}. "
-        f"Use this as a follow-up to search_{community_id}_code_docs when the snippet "
-        "appears truncated and the user is asking about specific outputs, parameters, "
-        "or examples. Takes an exact symbol_name (case-insensitive)."
+        f"Fetch the stored docstring in full (up to ~10K chars) for a specific "
+        f"symbol in {community_name}. Use this as a follow-up to "
+        f"search_{community_id}_code_docs when the snippet appears truncated "
+        "(marked with `...`) and the user is asking about specific outputs, "
+        "parameters, or examples. Takes an exact symbol_name (case-insensitive). "
+        "Returns up to 5 matches when the same symbol appears in multiple "
+        "files/repos."
     )
 
     return StructuredTool.from_function(

--- a/src/tools/knowledge.py
+++ b/src/tools/knowledge.py
@@ -23,6 +23,7 @@ from langchain_core.tools import BaseTool, StructuredTool
 
 from src.knowledge.db import get_db_path
 from src.knowledge.search import (
+    get_full_docstring,
     list_recent_github_items,
     search_discourse_topics,
     search_docstrings,
@@ -308,21 +309,100 @@ def create_search_docstrings_tool(
             lines.append(f"- {r.title}")
             lines.append(f"  [View source on GitHub]({r.url})")
             if r.snippet:
-                snippet = r.snippet[:200] + "..." if len(r.snippet) > 200 else r.snippet
-                lines.append(f"  Documentation: {snippet}")
+                lines.append(f"  Documentation: {r.snippet}")
             lines.append("")
+        lines.append(
+            f"If a snippet appears truncated and the user is asking about specific "
+            f"outputs, parameters, or examples, call get_{community_id}_full_docstring "
+            f"with the symbol_name to retrieve the complete docstring."
+        )
 
         return "\n".join(lines)
 
     description = (
         f"Search {community_name} code documentation (docstrings from functions, classes, scripts).{lang_help} "
         "Use this to find how specific functions work, what parameters they accept, "
-        "and see usage examples. Results include direct links to source code on GitHub."
+        "and see usage examples. Results include direct links to source code on GitHub. "
+        "If the returned snippet is truncated and you need full details about outputs, "
+        f"parameters, or examples, follow up with get_{community_id}_full_docstring."
     )
 
     return StructuredTool.from_function(
         func=search_docstrings_impl,
         name=f"search_{community_id}_code_docs",
+        description=description,
+    )
+
+
+def create_get_full_docstring_tool(
+    community_id: str,
+    community_name: str,
+    language: str | None = None,
+) -> BaseTool:
+    """Create a tool for fetching the complete docstring of a specific symbol.
+
+    Used as a follow-up after `search_{community_id}_code_docs` when the
+    returned snippet is truncated and the user is asking about specific
+    outputs, parameters, or examples that fall past the snippet cap.
+
+    Args:
+        community_id: The community identifier (e.g., 'hed', 'eeglab')
+        community_name: Display name (e.g., 'HED', 'EEGLAB')
+        language: Optional language filter ('matlab' or 'python')
+
+    Returns:
+        A LangChain tool that returns the full docstring for a given symbol
+    """
+
+    def get_full_docstring_impl(symbol_name: str) -> str:
+        """Fetch the complete docstring for a symbol."""
+        if not _check_db_exists(community_id):
+            return (
+                f"Knowledge database for {community_name} not initialized. "
+                "Run 'osa sync init' and 'osa sync docstrings' to populate it."
+            )
+
+        try:
+            results = get_full_docstring(symbol_name, project=community_id, language=language)
+        except sqlite3.OperationalError as e:
+            if "no such table" in str(e):
+                logger.warning(
+                    "Docstrings table not initialized for %s",
+                    community_id,
+                    extra={"symbol_name": symbol_name, "community": community_id},
+                )
+                return (
+                    f"Knowledge database for {community_name} not initialized. "
+                    f"Run 'osa sync docstrings --community {community_id}' to populate it."
+                )
+            raise
+
+        if not results:
+            return (
+                f"No docstring found for symbol '{symbol_name}' in {community_name}. "
+                "Try search_{community_id}_code_docs first to find the correct symbol name."
+            ).format(community_id=community_id)
+
+        lines = [f"Full docstring(s) for '{symbol_name}' in {community_name}:\n"]
+        for r in results:
+            lines.append(f"## {r.title}")
+            lines.append(f"[View source on GitHub]({r.url})\n")
+            if r.snippet:
+                lines.append(r.snippet)
+            lines.append("")
+
+        return "\n".join(lines)
+
+    description = (
+        f"Fetch the COMPLETE docstring for a specific symbol in {community_name}. "
+        f"Use this as a follow-up to search_{community_id}_code_docs when the snippet "
+        "appears truncated and the user is asking about specific outputs, parameters, "
+        "or examples. Takes an exact symbol_name (case-insensitive)."
+    )
+
+    return StructuredTool.from_function(
+        func=get_full_docstring_impl,
+        name=f"get_{community_id}_full_docstring",
         description=description,
     )
 
@@ -544,6 +624,9 @@ def create_knowledge_tools(
     if include_docstrings:
         tools.append(
             create_search_docstrings_tool(community_id, community_name, docstrings_language)
+        )
+        tools.append(
+            create_get_full_docstring_tool(community_id, community_name, docstrings_language)
         )
 
     if include_faq:

--- a/tests/test_integration/test_docstring_workflow.py
+++ b/tests/test_integration/test_docstring_workflow.py
@@ -3,8 +3,42 @@
 import pytest
 
 from src.knowledge.db import get_db_path, get_stats, init_db
-from src.knowledge.search import search_docstrings
-from src.tools.knowledge import create_search_docstrings_tool
+from src.knowledge.search import get_full_docstring, search_docstrings
+from src.tools.knowledge import (
+    create_get_full_docstring_tool,
+    create_search_docstrings_tool,
+)
+
+EEG_CONTEXT_DOCSTRING = """EEG_CONTEXT - returns (in output 'delays') a matrix giving, for each event of specified
+                ("target") type(s), the latency (in ms) to the Nth preceding and/or following
+                urevents (if any) of specified ("neighbor") type(s). Return the target event
+                and urevent numbers, the neighbor urevent numbers, and the values of specified
+                urevent field(s) for each of the neighbor urevents.
+Usage:
+            >>  [targs,urnbrs,urnbrtypes,delays,tfields,urnfields] = ...
+                         eeg_context(EEG,{targets},{neighbors},[positions],{fields},alltargs);
+Required input:
+EEG         - EEGLAB dataset structure containing EEG.event and EEG.urevent sub-structures
+
+Optional inputs:
+targets     - string or cell array of strings naming event type(s) of the specified target
+              events {default | []: all events}
+neighbors   - string or cell array of strings naming event type(s) of the specified
+              neighboring urevents {default | []: any neighboring events}.
+[positions] - int vector giving the relative positions of 'neighbor' type urevents to return.
+fields      - string or cell array of strings naming one or more (ur)event field(s) to return
+              values for neighbor urevents. {default: no field info returned}
+alltargs    - string ('all'|[]) if 'all', return information about all target urevents,
+              even those on which no epoch in the current dataset is centered.
+Outputs:
+ targs      - size(ntargets,4) matrix giving the indices of target events in the event
+              structure in column 1 and in the urevent structure in column 2.
+ urnbrs     - matrix of indices of "neighbor" events in the URevent structure (NaN if none).
+ urnbrtypes - int array giving the urnbrs event type indices in the {neighbor} cell array.
+ delays     - matrix giving, for each {targets} type event, the latency of the delay (in ms).
+ tfields    - real or cell array of values of the requested (ur)event field(s) for the target.
+ urnfields  - real or cell array of values of the requested (ur)event field(s) for the neighbor.
+"""
 
 
 @pytest.fixture
@@ -337,4 +371,113 @@ def test_branch_fallback_for_null(clean_db):
     assert len(results) == 1
     assert "/blob/main/" in results[0].url, (
         f"Expected fallback to /blob/main/, got: {results[0].url}"
+    )
+
+
+def _insert_eeg_context(project: str) -> None:
+    """Insert the eeg_context docstring used by the issue #276 regression tests."""
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    with get_connection(project) as conn:
+        upsert_docstring(
+            conn,
+            repo="sccn/eeglab",
+            file_path="functions/popfunc/eeg_context.m",
+            language="matlab",
+            symbol_name="eeg_context",
+            symbol_type="function",
+            docstring=EEG_CONTEXT_DOCSTRING,
+            line_number=1,
+            branch="develop",
+        )
+        conn.commit()
+
+
+def test_search_snippet_includes_outputs_section(clean_db):
+    """Regression for #276: snippet must include the Outputs section.
+
+    Before the fix the snippet was capped at 200 chars, so the LLM never
+    saw output names past the first sentence. The cap is now 1500 chars,
+    which captures Usage/Parameters/Outputs for typical MATLAB docstrings.
+    """
+    _insert_eeg_context(clean_db)
+
+    results = search_docstrings("eeg_context", project=clean_db, limit=1)
+    assert len(results) == 1
+    snippet = results[0].snippet
+
+    # Outputs section must be present
+    assert "Outputs:" in snippet, (
+        f"Snippet missing Outputs section (len={len(snippet)}): {snippet[:300]}..."
+    )
+
+    # All six documented outputs must appear in the snippet
+    for output_name in ("targs", "urnbrs", "urnbrtypes", "delays", "tfields", "urnfields"):
+        assert output_name in snippet, (
+            f"Output '{output_name}' missing from snippet (len={len(snippet)})"
+        )
+
+
+def test_get_full_docstring_returns_complete_content(clean_db):
+    """get_full_docstring must return the entire stored docstring (no truncation)."""
+    _insert_eeg_context(clean_db)
+
+    results = get_full_docstring("eeg_context", project=clean_db)
+    assert len(results) == 1
+    full = results[0].snippet
+
+    # The returned snippet must equal the stored docstring byte-for-byte
+    assert full == EEG_CONTEXT_DOCSTRING, (
+        f"Expected full docstring ({len(EEG_CONTEXT_DOCSTRING)} chars), got {len(full)} chars"
+    )
+
+
+def test_get_full_docstring_is_case_insensitive(clean_db):
+    """Exact symbol lookup should ignore case to match what an LLM might pass."""
+    _insert_eeg_context(clean_db)
+
+    for query in ("eeg_context", "EEG_CONTEXT", "Eeg_Context"):
+        results = get_full_docstring(query, project=clean_db)
+        assert len(results) == 1, f"Failed for query={query!r}"
+
+
+def test_get_full_docstring_no_match(clean_db):
+    """Unknown symbols return empty list, not an error."""
+    _insert_eeg_context(clean_db)
+    assert get_full_docstring("does_not_exist", project=clean_db) == []
+
+
+def test_full_docstring_tool_returns_outputs(clean_db):
+    """End-to-end: the LLM-facing tool must surface all 6 outputs of eeg_context."""
+    _insert_eeg_context(clean_db)
+
+    tool = create_get_full_docstring_tool(clean_db, "EEGLAB", language="matlab")
+    result = tool.invoke({"symbol_name": "eeg_context"})
+
+    assert isinstance(result, str)
+    assert "View source on GitHub" in result
+    for output_name in ("targs", "urnbrs", "urnbrtypes", "delays", "tfields", "urnfields"):
+        assert output_name in result, f"Output '{output_name}' missing from tool output"
+
+
+def test_full_docstring_tool_unknown_symbol(clean_db):
+    """Tool must return a helpful message (not crash) for unknown symbols."""
+    _insert_eeg_context(clean_db)
+
+    tool = create_get_full_docstring_tool(clean_db, "EEGLAB", language="matlab")
+    result = tool.invoke({"symbol_name": "nope_not_real"})
+
+    assert isinstance(result, str)
+    assert "No docstring found" in result
+
+
+def test_search_tool_points_to_full_docstring_tool(clean_db):
+    """The search tool should hint at the follow-up tool name in its output."""
+    _insert_eeg_context(clean_db)
+
+    tool = create_search_docstrings_tool(clean_db, "EEGLAB", language="matlab")
+    result = tool.invoke({"query": "eeg_context", "limit": 1})
+
+    assert f"get_{clean_db}_full_docstring" in result, (
+        "Search tool output should mention the full-docstring follow-up tool name"
     )

--- a/tests/test_integration/test_docstring_workflow.py
+++ b/tests/test_integration/test_docstring_workflow.py
@@ -472,12 +472,216 @@ def test_full_docstring_tool_unknown_symbol(clean_db):
 
 
 def test_search_tool_points_to_full_docstring_tool(clean_db):
-    """The search tool should hint at the follow-up tool name in its output."""
+    """The search tool should hint at the follow-up tool name when truncation occurred."""
     _insert_eeg_context(clean_db)
 
     tool = create_search_docstrings_tool(clean_db, "EEGLAB", language="matlab")
     result = tool.invoke({"query": "eeg_context", "limit": 1})
 
+    # eeg_context (~1900 chars) exceeds the 1500-char snippet cap, so the
+    # hint must be appended.
     assert f"get_{clean_db}_full_docstring" in result, (
         "Search tool output should mention the full-docstring follow-up tool name"
+    )
+
+
+def test_snippet_cap_truncates_past_boundary(clean_db):
+    """Regression for #276 reviewer feedback: pin the 1500-char snippet cap.
+
+    Constructs a docstring whose marker content sits past char 1500.
+    Asserts the snippet does NOT contain it (truncation occurred at the
+    cap) and that get_full_docstring DOES return it. Without this test
+    a future revert of DOCSTRING_SNIPPET_MAX_LENGTH could silently
+    reintroduce the original bug.
+    """
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    # 1600 chars of padding so the marker is past the 1500-char cap.
+    padding = "lorem ipsum dolor sit amet, " * 60  # ~28 chars * 60 = ~1680
+    assert len(padding) > 1500
+    marker = "ZZZ_PAST_CAP_MARKER_ZZZ"
+    docstring = padding + "\nOutputs:\n  " + marker
+
+    with get_connection(clean_db) as conn:
+        upsert_docstring(
+            conn,
+            repo="sccn/eeglab",
+            file_path="functions/test_cap.m",
+            language="matlab",
+            symbol_name="cap_boundary_fn",
+            symbol_type="function",
+            docstring=docstring,
+            line_number=1,
+        )
+        conn.commit()
+
+    # Snippet truncates before the marker
+    results = search_docstrings("cap_boundary_fn", project=clean_db, limit=1)
+    assert len(results) == 1
+    snippet = results[0].snippet
+    assert len(snippet) <= 1500 + 3  # cap + "..."
+    assert snippet.endswith("..."), "Snippet should be marked as truncated"
+    assert marker not in snippet, "Snippet must not contain content past the cap"
+
+    # Full fetch returns it
+    full_results = get_full_docstring("cap_boundary_fn", project=clean_db)
+    assert len(full_results) == 1
+    assert marker in full_results[0].snippet, "Full fetch must return content past cap"
+
+
+def test_get_full_docstring_repo_filter_disambiguates(clean_db):
+    """repo filter must narrow multi-repo matches to one."""
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    with get_connection(clean_db) as conn:
+        upsert_docstring(
+            conn,
+            repo="sccn/eeglab",
+            file_path="functions/plot.m",
+            language="matlab",
+            symbol_name="plot",
+            symbol_type="function",
+            docstring="EEGLAB plot helper",
+            line_number=1,
+        )
+        upsert_docstring(
+            conn,
+            repo="fieldtrip/fieldtrip",
+            file_path="utilities/plot.m",
+            language="matlab",
+            symbol_name="plot",
+            symbol_type="function",
+            docstring="FieldTrip plot helper",
+            line_number=1,
+        )
+        conn.commit()
+
+    # No filter: both rows returned (and ordered deterministically)
+    both = get_full_docstring("plot", project=clean_db)
+    assert len(both) == 2
+    repos = [r.url.split("github.com/")[1].split("/blob/")[0] for r in both]
+    assert repos == sorted(repos), "ORDER BY repo must give deterministic order"
+
+    # Filter narrows to the chosen repo
+    filtered = get_full_docstring("plot", project=clean_db, repo="sccn/eeglab")
+    assert len(filtered) == 1
+    assert "sccn/eeglab" in filtered[0].url
+
+
+def test_get_full_docstring_language_filter(clean_db):
+    """language filter must narrow to the chosen language."""
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    with get_connection(clean_db) as conn:
+        upsert_docstring(
+            conn,
+            repo="org/repo",
+            file_path="lib/load.m",
+            language="matlab",
+            symbol_name="load_data",
+            symbol_type="function",
+            docstring="MATLAB load_data",
+            line_number=1,
+        )
+        upsert_docstring(
+            conn,
+            repo="org/repo",
+            file_path="lib/load.py",
+            language="python",
+            symbol_name="load_data",
+            symbol_type="function",
+            docstring="Python load_data",
+            line_number=1,
+        )
+        conn.commit()
+
+    matlab_only = get_full_docstring("load_data", project=clean_db, language="matlab")
+    assert len(matlab_only) == 1
+    assert "MATLAB load_data" in matlab_only[0].snippet
+
+    python_only = get_full_docstring("load_data", project=clean_db, language="python")
+    assert len(python_only) == 1
+    assert "Python load_data" in python_only[0].snippet
+
+
+def test_get_full_docstring_respects_limit(clean_db):
+    """Default limit must cap unbounded payloads for common symbol names."""
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    with get_connection(clean_db) as conn:
+        for i in range(8):
+            upsert_docstring(
+                conn,
+                repo=f"org/repo{i}",
+                file_path=f"file_{i}.m",
+                language="matlab",
+                symbol_name="init",
+                symbol_type="function",
+                docstring=f"init implementation {i}",
+                line_number=1,
+            )
+        conn.commit()
+
+    results = get_full_docstring("init", project=clean_db)  # default limit
+    assert len(results) == 5, f"Expected default limit of 5, got {len(results)}"
+
+    custom = get_full_docstring("init", project=clean_db, limit=2)
+    assert len(custom) == 2
+
+
+def test_get_full_docstring_skips_empty_stored_docstring(clean_db):
+    """An empty stored docstring is logged and skipped, not returned as a phantom hit."""
+    from src.knowledge.db import get_connection
+
+    with get_connection(clean_db) as conn:
+        # Insert with empty docstring directly (upsert_docstring requires a str
+        # but doesn't reject empty)
+        conn.execute(
+            """
+            INSERT INTO docstrings (repo, file_path, language, symbol_name,
+                                   symbol_type, docstring, line_number, branch, synced_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            """,
+            ("org/repo", "f.m", "matlab", "empty_fn", "function", "", 1, "main"),
+        )
+        conn.commit()
+
+    results = get_full_docstring("empty_fn", project=clean_db)
+    assert results == [], "Empty-bodied rows must be skipped, not returned"
+
+
+def test_full_docstring_tool_handles_symbol_with_braces(clean_db):
+    """Regression: tool's no-match message must not crash on `{` in symbol names."""
+    _insert_eeg_context(clean_db)
+
+    tool = create_get_full_docstring_tool(clean_db, "EEGLAB", language="matlab")
+    # Earlier code used .format() on an f-string that contained the user's
+    # input verbatim; a `{` in the symbol name caused KeyError.
+    result = tool.invoke({"symbol_name": "no_{such}_symbol"})
+    assert isinstance(result, str)
+    assert "No docstring found" in result
+
+
+def test_search_tool_omits_hint_when_no_truncation(clean_db):
+    """Search results that fit within the snippet cap should not nudge full-fetch."""
+    from src.knowledge.db import get_connection, upsert_docstring
+
+    with get_connection(clean_db) as conn:
+        upsert_docstring(
+            conn,
+            repo="sccn/eeglab",
+            file_path="functions/short.m",
+            language="matlab",
+            symbol_name="short_fn",
+            symbol_type="function",
+            docstring="Tiny docstring that easily fits inside the snippet cap.",
+            line_number=1,
+        )
+        conn.commit()
+
+    tool = create_search_docstrings_tool(clean_db, "EEGLAB", language="matlab")
+    result = tool.invoke({"query": "short_fn", "limit": 1})
+
+    assert f"get_{clean_db}_full_docstring" not in result, (
+        "Hint should be omitted when no snippet was truncated"
     )

--- a/tests/test_tools/test_knowledge_tools.py
+++ b/tests/test_tools/test_knowledge_tools.py
@@ -269,11 +269,13 @@ class TestCreateKnowledgeTools:
         assert "repo1" in discussion_tool.description
 
     def test_includes_docstrings_tool_when_enabled(self) -> None:
-        """Should include docstring search tool when include_docstrings=True."""
+        """Should include docstring search + full-fetch tools when include_docstrings=True."""
         tools = create_knowledge_tools("test", "Test", include_docstrings=True)
         tool_names = [t.name for t in tools]
         assert "search_test_code_docs" in tool_names
-        assert len(tools) == 4
+        # Paired full-fetch tool added for issue #276
+        assert "get_test_full_docstring" in tool_names
+        assert len(tools) == 5
 
     def test_includes_faq_tool_when_enabled(self) -> None:
         """Should include FAQ search tool when include_faq=True."""
@@ -296,9 +298,10 @@ class TestCreateKnowledgeTools:
         )
         tool_names = [t.name for t in tools]
         assert "search_test_code_docs" in tool_names
+        assert "get_test_full_docstring" in tool_names
         assert "search_test_faq" in tool_names
         assert "search_test_forum" in tool_names
-        assert len(tools) == 6
+        assert len(tools) == 7
 
 
 class TestSearchDocstringsTool:

--- a/tests/test_tools/test_knowledge_tools.py
+++ b/tests/test_tools/test_knowledge_tools.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from src.knowledge.db import get_connection, init_db, upsert_github_item, upsert_paper
 from src.tools.knowledge import (
+    create_get_full_docstring_tool,
     create_knowledge_tools,
     create_list_recent_tool,
     create_search_discourse_tool,
@@ -321,6 +322,41 @@ class TestSearchDocstringsTool:
 
         with patch("src.tools.knowledge.get_db_path", return_value=db_path):
             result = tool.invoke({"query": "some_function"})
+        assert "not initialized" in result.lower()
+        assert "osa sync docstrings" in result
+
+
+class TestGetFullDocstringTool:
+    """Tests for the full-docstring follow-up tool."""
+
+    def test_returns_error_when_db_not_exists(self, tmp_path: Path) -> None:
+        """Should return initialization message when DB doesn't exist."""
+        tool = create_get_full_docstring_tool("test", "Test Community")
+
+        db_path = tmp_path / "knowledge" / "test.db"
+        with patch("src.tools.knowledge.get_db_path", return_value=db_path):
+            result = tool.invoke({"symbol_name": "any_symbol"})
+        assert "not initialized" in result.lower()
+
+    def test_handles_missing_table(self, tmp_path: Path) -> None:
+        """Should return friendly message when docstrings table doesn't exist.
+
+        Mirrors TestSearchDocstringsTool::test_handles_missing_table so the
+        case-insensitive 'no such table' match in the tool wrapper is
+        actually exercised.
+        """
+        import sqlite3
+
+        tool = create_get_full_docstring_tool("test", "Test Community")
+
+        db_path = tmp_path / "knowledge" / "test.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE dummy (id INTEGER)")
+        conn.close()
+
+        with patch("src.tools.knowledge.get_db_path", return_value=db_path):
+            result = tool.invoke({"symbol_name": "any_symbol"})
         assert "not initialized" in result.lower()
         assert "osa sync docstrings" in result
 


### PR DESCRIPTION
## Summary

EEGLAB assistant gave incomplete answers about `eeg_context`, reporting only `delays` when the function actually documents **6 outputs**: `targs`, `urnbrs`, `urnbrtypes`, `delays`, `tfields`, `urnfields`. Root cause: docstring snippets were truncated to 200 chars before reaching the LLM via two stacked truncations, so the model never saw the `Outputs:` section.

For `eeg_context` (6598 chars total), the `Outputs:` section starts past char 1700, so even a 1000-char cap would still cut it off.

## Changes

- **`src/knowledge/search.py`**: bump docstring snippet cap to **1500 chars** so Usage / Parameters / Outputs fit in the default search result; add `get_full_docstring(symbol_name, project, language, repo)` returning the complete docstring via case-insensitive exact lookup.
- **`src/tools/knowledge.py`**: drop the redundant `[:200]` truncation in `search_docstrings_impl`; add `create_get_full_docstring_tool` factory and register it alongside `search_docstrings` when `include_docstrings=True`; nudge the LLM toward the new tool in both the description and the search response footer.
- **Tests**: regression tests asserting all six `eeg_context` outputs appear in both the snippet and the full-fetch tool output; update tool-count expectations in `test_knowledge_tools.py`.

## Behavior

| Before | After |
| --- | --- |
| Search returns 200-char snippet (just opening sentence) | Search returns up to 1500 chars (catches Usage + Outputs for most MATLAB docs) |
| No way to get the complete docstring | `get_<community>_full_docstring(symbol_name)` returns the full stored docstring |
| LLM hallucinated/punted on outputs past char 200 | LLM has the structured Outputs section in-context and can follow up via full-fetch when needed |

## Test plan

- [x] `uv run pytest tests/test_knowledge tests/test_tools tests/test_integration/test_docstring_workflow.py` (490 pass)
- [x] `uv run ruff check` clean
- [ ] After merge + dev deploy: re-ask "What are the outputs of `eeg_context`?" against EEGLAB assistant; expect all 6 outputs named

Closes #276