### PR TITLE
feat: document versioned widget URL and SRI hashes for secure embedding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,38 @@ jobs:
           EOF
 
           echo "Generated release notes for v${{ steps.version.outputs.version }}"
+      - name: Append widget SRI hash to release notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          HASH=$(python3 -c "
+          import hashlib, base64
+          with open('frontend/osa-chat-widget.js', 'rb') as f:
+              content = f.read()
+          print('sha384-' + base64.b64encode(hashlib.sha384(content).digest()).decode())
+          ")
+          python3 - <<PYEOF
+          import pathlib
+          notes = pathlib.Path('/tmp/release_notes.md').read_text()
+          section = f"""
+      
+      ## Widget Embedding
+      
+      **Standard** (always latest):
+      \`\`\`html
+      <script src="https://demo.osc.earth/osa-chat-widget.js"></script>
+      \`\`\`
+      
+      **Versioned + SRI** (for supply-chain-secure environments):
+      \`\`\`html
+      <script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@v${VERSION}/frontend/osa-chat-widget.js"
+              integrity="${HASH}"
+              crossorigin="anonymous"
+              defer></script>
+      \`\`\`
+      > Pin to this exact release. Update the tag when upgrading.
+      """
+          pathlib.Path('/tmp/release_notes.md').write_text(notes + section)
+          PYEOF
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -391,6 +391,17 @@
   });
 &lt;/script&gt;</code></pre>
           <p>The widget auto-configures the API endpoint based on the <code>communityId</code>.</p>
+          <hr style="margin: 16px 0; border: none; border-top: 1px solid #e5e7eb;">
+          <p><strong>Security-sensitive environments</strong> (supply-chain policies, SRI required): pin to a specific release using a versioned jsDelivr URL. The <code>integrity</code> hash for each release is published in the <a href="https://github.com/OpenScience-Collective/osa/releases" target="_blank" rel="noopener noreferrer">GitHub releases</a>.</p>
+          <pre><code>&lt;!-- Replace vX.Y.Z and the integrity hash from the GitHub release notes --&gt;
+&lt;script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@vX.Y.Z/frontend/osa-chat-widget.js"
+        integrity="sha384-..."
+        crossorigin="anonymous"
+        defer&gt;&lt;/script&gt;
+&lt;script&gt;
+  OSAChatWidget.setConfig({ communityId: 'hed' });
+&lt;/script&gt;</code></pre>
+          <p style="font-size: 13px; color: #6b7280;">Note: you must update the version tag manually when upgrading.</p>
         </div>
 
         <div class="info-box">
@@ -479,6 +490,17 @@
     // widgetInstructions: 'Focus on topics relevant to this page.'
   });
 &lt;/script&gt;</code></pre>
+          <hr style="margin: 16px 0; border: none; border-top: 1px solid #e5e7eb;">
+          <p><strong>Security-sensitive environments</strong> (supply-chain policies, SRI required): use a versioned URL pinned to a specific release. The <code>integrity</code> hash for each release is published in the <a href="https://github.com/OpenScience-Collective/osa/releases" target="_blank" rel="noopener noreferrer">GitHub releases</a>.</p>
+          <pre><code>&lt;!-- Replace vX.Y.Z and the integrity hash from the GitHub release notes --&gt;
+&lt;script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@vX.Y.Z/frontend/osa-chat-widget.js"
+        integrity="sha384-..."
+        crossorigin="anonymous"
+        defer&gt;&lt;/script&gt;
+&lt;script&gt;
+  OSAChatWidget.setConfig({ communityId: '${communityId}' });
+&lt;/script&gt;</code></pre>
+          <p style="font-size: 13px; color: #6b7280;">Note: you must update the version tag manually when upgrading.</p>
         </div>
 
         <div class="info-box">

--- a/scripts/widget-sri.py
+++ b/scripts/widget-sri.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate the SRI hash for the OSA chat widget.
+
+Usage:
+  # Hash the local file (useful during development / CI before a release is tagged)
+  python scripts/widget-sri.py
+
+  # Hash a specific release from jsDelivr (useful after tagging)
+  python scripts/widget-sri.py v0.8.3
+
+The script prints the sha384 integrity value and a ready-to-paste embed snippet.
+"""
+
+import base64
+import hashlib
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def sri(content: bytes) -> str:
+    return "sha384-" + base64.b64encode(hashlib.sha384(content).digest()).decode()
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        tag = sys.argv[1] if sys.argv[1].startswith("v") else f"v{sys.argv[1]}"
+        url = (
+            f"https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@{tag}"
+            "/frontend/osa-chat-widget.js"
+        )
+        print(f"Fetching {url} …", flush=True)
+        with urllib.request.urlopen(url) as resp:  # noqa: S310 (trusted CDN URL)
+            content = resp.read()
+        label = f"jsDelivr {tag}"
+    else:
+        widget_path = Path(__file__).parent.parent / "frontend" / "osa-chat-widget.js"
+        if not widget_path.exists():
+            print(f"Error: {widget_path} not found.", file=sys.stderr)
+            print("Pass a version tag to fetch from jsDelivr instead:", file=sys.stderr)
+            print("  python scripts/widget-sri.py v0.8.3", file=sys.stderr)
+            sys.exit(1)
+        content = widget_path.read_bytes()
+        tag = None
+        label = f"local ({widget_path.name})"
+
+    hash_value = sri(content)
+    print(f"\nSRI hash ({label}):")
+    print(f"  integrity=\"{hash_value}\"")
+
+    if tag:
+        print(f"\nVersioned embed snippet for {tag}:")
+        print(f"""\
+  <script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@{tag}/frontend/osa-chat-widget.js"
+          integrity="{hash_value}"
+          crossorigin="anonymous"
+          defer></script>""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add security-sensitive embedding documentation to the widget demo page and a utility script for generating SRI hashes.

Closes #268

Generated with [Claude Code](https://claude.ai/code)