### PR TITLE
feat: community-admin scoped PR auto-merge

### DIFF
--- a/.context/community-admin-merge.md
+++ b/.context/community-admin-merge.md
@@ -17,8 +17,9 @@ When a PR is opened, synchronized, reopened, or marked ready-for-review against
    (one community, nothing outside it).
 3. Reads the `maintainers:` list from the BASE branch copy of
    `src/assistants/<id>/config.yaml`.
-4. Confirms the PR author is in that list (case-insensitive).
-5. Confirms the PR does NOT change the `maintainers:` field itself.
+4. Confirms the PR does NOT change the `maintainers:` field itself (a covert
+   admin-list change is rejected before the author is even considered).
+5. Confirms the PR author is in that list (case-insensitive).
 6. If all checks pass: approves the PR and enables a SQUASH auto-merge using a
    dedicated GitHub App token. The merge fires only after required checks pass.
 
@@ -60,8 +61,10 @@ App.
 ## One-time setup (human)
 
 These steps are done once by a repo admin. Until they are complete, the workflow
-runs but no-ops on the token-mint step (it will fail to mint without the
-secrets), so finish all steps before relying on it.
+evaluates every PR but skips the write steps (mint, approve, merge) for
+ineligible PRs. If an *eligible* PR is opened before the secrets exist, the
+token-mint step fails with an error (the PR is not merged). Finish all steps
+before relying on it.
 
 ### 1. Create the GitHub App
 

--- a/.context/community-admin-merge.md
+++ b/.context/community-admin-merge.md
@@ -1,0 +1,163 @@
+# Community Admin Auto-Merge
+
+Lets a community maintainer auto-merge a pull request (PR) that touches ONLY
+their own community's directory, without waiting on a human reviewer. The normal
+required status checks (ruff + tests) still gate the actual merge, so this only
+removes the human-approval step, not the CI gate.
+
+Workflow file: `.github/workflows/community-admin-pr-merge.yml`
+
+## What it does
+
+When a PR is opened, synchronized, reopened, or marked ready-for-review against
+`develop` or `main`, the workflow:
+
+1. Reads the PR's changed-file list via the GitHub API.
+2. Confirms every changed path is under a single `src/assistants/<id>/` tree
+   (one community, nothing outside it).
+3. Reads the `maintainers:` list from the BASE branch copy of
+   `src/assistants/<id>/config.yaml`.
+4. Confirms the PR author is in that list (case-insensitive).
+5. Confirms the PR does NOT change the `maintainers:` field itself.
+6. If all checks pass: approves the PR and enables a SQUASH auto-merge using a
+   dedicated GitHub App token. The merge fires only after required checks pass.
+
+If any check fails, or anything is ambiguous, the workflow no-ops (logs a notice
+and exits cleanly). The PR then follows the normal human-review path. Default
+posture is "do not merge".
+
+## Trust model
+
+- Source of truth for authorization is the `maintainers:` list in the
+  community's `config.yaml`, read from the BASE branch (the already-merged,
+  trusted code), NEVER from the PR head. This prevents a PR from granting itself
+  merge rights by adding its author to the list in the same change.
+- Scope is path-restricted to exactly one `src/assistants/<id>/` directory.
+  A PR that touches two communities, or touches anything outside a community
+  directory (including `src/version.py`, CI, top-level files), is ineligible.
+- Edits to the `maintainers:` field are excluded from auto-merge. Changing who
+  holds admin power always requires human review. The workflow detects this by
+  parsing the base vs head copies of `config.yaml` and comparing the normalized
+  maintainers lists.
+- The actual merge still requires all branch-protection required checks to be
+  green. Auto-merge only removes the manual-approval gate.
+- The workflow uses `pull_request_target` so it has access to secrets even for
+  fork PRs, but it NEVER checks out or executes PR-head code. The only checkout
+  is the trusted base branch; the PR diff is read through the API only. The head
+  copy of `config.yaml` is fetched and parsed solely to compare the maintainers
+  field; it is never executed.
+
+## Token model
+
+All write actions (approve + merge + confirmation comment) use a SHORT-LIVED
+installation token minted from a dedicated GitHub App via
+`actions/create-github-app-token@v1`. This App is independent from the
+`CI_ADMIN_TOKEN` personal access token (PAT) used by the version-automation
+workflows. The workflow's own `GITHUB_TOKEN` is kept at `contents: read` only,
+so the workflow has no standing write power; every write is attributable to the
+App.
+
+## One-time setup (human)
+
+These steps are done once by a repo admin. Until they are complete, the workflow
+runs but no-ops on the token-mint step (it will fail to mint without the
+secrets), so finish all steps before relying on it.
+
+### 1. Create the GitHub App
+
+GitHub -> Settings (your org `OpenScience-Collective`) -> Developer settings ->
+GitHub Apps -> New GitHub App.
+
+- GitHub App name: e.g. `OSA Community Auto-Merge`.
+- Homepage URL: the repo URL is fine (`https://github.com/OpenScience-Collective/osa`).
+- Webhook: UNCHECK "Active". No webhook is needed; the Action invokes the App by
+  minting a token, the App does not need to receive events.
+- Repository permissions (set ONLY these; leave everything else "No access"):
+  - Pull requests: Read and write  (needed to approve and to enable auto-merge)
+  - Contents: Read and write       (needed for the squash merge to write the commit)
+  - Metadata: Read-only            (mandatory; GitHub sets this automatically)
+- Organization permissions: none.
+- Account permissions: none.
+- "Where can this GitHub App be installed?": Only on this account.
+
+Create the App. Note the App ID shown on the App's settings page.
+
+### 2. Install the App on this repo
+
+From the App's settings page -> Install App -> install it on
+`OpenScience-Collective`, and restrict it to the `osa` repository only
+("Only select repositories" -> `osa`).
+
+### 3. Generate a private key
+
+On the App's settings page -> "Private keys" -> "Generate a private key". This
+downloads a `.pem` file. Keep it secret; you will paste its full contents into a
+repo secret in the next step. You cannot retrieve it again later, only generate
+a new one.
+
+### 4. Add the two repo secrets
+
+Repo -> Settings -> Secrets and variables -> Actions -> New repository secret:
+
+- `COMMUNITY_MERGE_APP_ID` = the numeric App ID from step 1.
+- `COMMUNITY_MERGE_APP_PRIVATE_KEY` = the full contents of the `.pem` file from
+  step 3 (including the `-----BEGIN ... KEY-----` / `-----END ... KEY-----`
+  lines).
+
+### 5. Enable "Allow auto-merge" on the repo
+
+The workflow uses `gh pr merge --auto`, which requires the repository-level
+auto-merge feature to be turned on. Repo -> Settings -> General -> "Pull
+Requests" section -> check "Allow auto-merge". Without this, the merge step
+fails (the PR will still be approved, but it will not merge automatically).
+
+### 6. Let the App merge past branch protection
+
+Branch protection on `develop` and `main` is configured in the GitHub UI (not in
+the repo). Make sure the App is allowed to merge:
+
+- Required status checks must stay ON (ruff + tests). The App does NOT bypass
+  these; auto-merge waits for them. Do not add the App to any
+  "allow specified actors to bypass required pull requests / status checks"
+  allowlist; it should merge through the same gate everyone else uses.
+- If a branch has "Restrict who can push to matching branches" (a push/merge
+  allowlist) enabled, add the GitHub App to that allowlist so its merge is
+  permitted. If that restriction is not enabled, no action is needed.
+- "Require approvals" can stay on; the App's approval satisfies it. If you use
+  "Dismiss stale approvals", note that a new push will dismiss the App's
+  approval and the workflow will re-approve on the next `synchronize` event.
+
+## How a community admin uses it
+
+1. Open a PR against `develop` (or `main`) that changes only files inside your
+   community directory, `src/assistants/<your-id>/` (config.yaml, tools.py,
+   prompts, logo, etc.).
+2. Make sure you are a listed maintainer in that directory's `config.yaml`.
+3. Do not change the `maintainers:` field in the same PR; that needs human
+   review.
+4. The workflow approves the PR and enables squash auto-merge. The PR merges
+   automatically once ruff and the test suite pass. A confirmation comment is
+   posted (and updated in place on later pushes, not duplicated).
+
+If your PR is not eligible (touches more than one community, touches files
+outside your directory, changes the maintainers list, or you are not a listed
+maintainer), the workflow simply does nothing and the PR follows the normal
+review process.
+
+## Security notes and limitations
+
+- The `maintainers:` list is hand-maintained in each `config.yaml`. There is no
+  sync with GitHub Teams or org membership; whoever is listed there is trusted to
+  merge changes to that community's directory.
+- Adding or removing a maintainer is intentionally excluded from auto-merge and
+  always requires a human-reviewed PR.
+- A brand-new community (no `config.yaml` on the base branch yet) cannot be
+  auto-merged, because there is no trusted maintainers list to authorize
+  against. The first PR introducing a community needs human review.
+- A `config.yaml` that fails to parse (malformed YAML, missing or empty
+  maintainers, non-string entries) is treated as "not eligible".
+- Auto-merging community changes into `main` will NOT cut a release. Releases
+  are triggered by changes to `src/version.py`, and community PRs are
+  path-restricted so they never touch it.
+- The workflow uses `pull_request_target` but never runs PR-head code; see the
+  Trust model section and the comment block at the top of the workflow file.

--- a/.github/workflows/community-admin-pr-merge.yml
+++ b/.github/workflows/community-admin-pr-merge.yml
@@ -28,9 +28,10 @@ name: Community Admin PR Auto-Merge
 # -----------------------------------------------------------------------------
 # Token model
 # -----------------------------------------------------------------------------
-# GITHUB_TOKEN cannot approve a PR (a token cannot approve its own context) and,
-# more importantly, we deliberately keep its permissions minimal (contents:read)
-# so this workflow has no standing write power. All write actions (approve +
+# GITHUB_TOKEN cannot approve a PR (GitHub prohibits a workflow's own token from
+# submitting a review on the PR that triggered it) and, more importantly, we
+# deliberately keep its permissions minimal (read-only) so this workflow has no
+# standing write power. All write actions (approve +
 # merge) are performed with a SHORT-LIVED installation token minted from a
 # dedicated GitHub App via actions/create-github-app-token. The App is the only
 # identity allowed to merge here, and it is independent from the CI_ADMIN_TOKEN
@@ -44,11 +45,13 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [develop, main]
 
-# Minimal standing permissions. The checkout only needs read. Every write
-# (approve, merge, comment) happens through the GitHub App installation token
-# minted below, NOT through GITHUB_TOKEN.
+# Minimal standing permissions. contents:read for the base checkout; the
+# eligibility step reads the PR's file list with github.token, which needs
+# pull-requests:read. Every WRITE (approve, merge, comment) happens through the
+# GitHub App installation token minted below, NOT through GITHUB_TOKEN.
 permissions:
   contents: read
+  pull-requests: read
 
 # One in-flight evaluation per PR; cancel stale runs on rapid synchronize.
 concurrency:
@@ -64,13 +67,12 @@ jobs:
     steps:
       # Checkout the BASE branch ONLY. This is trusted, already-merged code.
       # We never check out github.event.pull_request.head; the PR diff is read
-      # via the API in later steps. fetch-depth: 0 so we can `git show` the
-      # base and merge-base of config.yaml for the maintainers comparison.
+      # via the API in later steps. We only ever `git show` BASE_SHA:config.yaml,
+      # and `ref: base.sha` guarantees that commit is present locally.
       - name: Checkout base branch (trusted)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
@@ -90,10 +92,14 @@ jobs:
       # ----------------------------------------------------------------------
       - name: Evaluate eligibility
         id: eval
+        # All PR-controlled values are passed via env (never interpolated into
+        # the script body) so a crafted login/sha/ref cannot inject shell.
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -109,11 +115,21 @@ jobs:
             exit 0
           }
 
-          # 1. Get the PR's changed files from the GitHub API. We do NOT diff
-          #    locally against PR-head code. --name-only across all statuses
-          #    (added/modified/removed/renamed). For a rename, gh lists the new
-          #    path; that still must fall under the community dir to be eligible.
-          mapfile -t CHANGED < <(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          # 1. Get the PR's changed files from the GitHub API (metadata only; we
+          #    never merge or execute PR-head code). We use the paginated
+          #    /pulls/{n}/files endpoint, NOT `gh pr diff --name-only`, for two
+          #    reasons that are load-bearing for security:
+          #      - It emits BOTH `.filename` (new path) and `.previous_filename`
+          #        (a rename's OLD path). Checking both prevents a rename that
+          #        moves a file FROM outside the community dir INTO it (the old
+          #        path would be out of scope) from slipping the scope check.
+          #      - `--paginate` returns ALL files; `gh pr diff` truncates large
+          #        PRs at 300 files, which could hide out-of-scope files past the
+          #        cutoff.
+          mapfile -t CHANGED < <(
+            gh api --paginate "/repos/$REPO/pulls/$PR_NUMBER/files" \
+              -q '.[] | (.filename, (.previous_filename // empty))' | sort -u
+          )
 
           if [ "${#CHANGED[@]}" -eq 0 ]; then
             not_eligible "PR changes zero files"
@@ -221,10 +237,11 @@ jobs:
             echo "config.yaml is modified; verifying maintainers field is unchanged"
 
             # Fetch the HEAD version of config.yaml via the API (raw contents at
-            # the PR head sha). We parse it ONLY to compare the maintainers
-            # field; we never execute it. A failure to fetch/parse the head
-            # config => not eligible (conservative default).
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            # the PR head sha, from $HEAD_SHA in env). We parse it ONLY to compare
+            # the maintainers field; we never execute it. A failure to fetch/parse
+            # the head config => not eligible (conservative default). This also
+            # catches a config.yaml that the PR deleted or renamed away (the fetch
+            # 404s), so admin-list removal cannot ride through.
             if ! gh api \
                   -H "Accept: application/vnd.github.raw+json" \
                   "/repos/$REPO/contents/$CONFIG_PATH?ref=$HEAD_SHA" \
@@ -269,7 +286,8 @@ jobs:
 
           # 6. Verify the PR author is in the BASE-branch maintainers list.
           #    GitHub usernames are case-insensitive, so compare lowercased.
-          AUTHOR="$(printf '%s' "${{ github.event.pull_request.user.login }}" | tr '[:upper:]' '[:lower:]')"
+          #    AUTHOR_LOGIN comes from env (never interpolated into the script).
+          AUTHOR="$(printf '%s' "$AUTHOR_LOGIN" | tr '[:upper:]' '[:lower:]')"
           echo "PR author (normalized): $AUTHOR"
           if ! grep -qxF "$AUTHOR" /tmp/base_maintainers.txt; then
             not_eligible "author '$AUTHOR' is not a maintainer of '$COMMUNITY'"

--- a/.github/workflows/community-admin-pr-merge.yml
+++ b/.github/workflows/community-admin-pr-merge.yml
@@ -1,0 +1,368 @@
+name: Community Admin PR Auto-Merge
+
+# Lets a community maintainer auto-merge a PR that ONLY touches their own
+# community's directory (src/assistants/<id>/**). When eligible, this workflow
+# approves the PR and enables squash auto-merge so the normal required status
+# checks (ruff + tests) still gate the actual merge.
+#
+# -----------------------------------------------------------------------------
+# Trigger choice: pull_request_target (NOT pull_request)
+# -----------------------------------------------------------------------------
+# We need to approve + merge, which requires a privileged token. On a plain
+# `pull_request` event from a fork, secrets are NOT available, so we could not
+# mint the GitHub App token. `pull_request_target` runs in the context of the
+# BASE repo and therefore HAS access to secrets even for fork PRs.
+#
+# The well-known danger of pull_request_target is that it can be tricked into
+# executing attacker-controlled PR-head code with secrets in scope. We avoid
+# that entirely:
+#   - We NEVER check out the PR head. The only checkout is the BASE branch
+#     (the trusted, already-reviewed code), and we never run anything from the
+#     PR. The PR diff is read via the GitHub API only.
+#   - Authorization (the maintainers list) is read from the BASE branch version
+#     of config.yaml, never from the PR head, so a PR cannot grant itself power.
+#   - If the PR's diff touches the `maintainers:` field of any config.yaml, the
+#     PR is ineligible and goes to human review.
+# Given these constraints, pull_request_target is the correct and safe choice.
+#
+# -----------------------------------------------------------------------------
+# Token model
+# -----------------------------------------------------------------------------
+# GITHUB_TOKEN cannot approve a PR (a token cannot approve its own context) and,
+# more importantly, we deliberately keep its permissions minimal (contents:read)
+# so this workflow has no standing write power. All write actions (approve +
+# merge) are performed with a SHORT-LIVED installation token minted from a
+# dedicated GitHub App via actions/create-github-app-token. The App is the only
+# identity allowed to merge here, and it is independent from the CI_ADMIN_TOKEN
+# PAT used by the version-automation workflows. Required secrets:
+#   - COMMUNITY_MERGE_APP_ID
+#   - COMMUNITY_MERGE_APP_PRIVATE_KEY
+# See .context/community-admin-merge.md for the one-time App setup.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [develop, main]
+
+# Minimal standing permissions. The checkout only needs read. Every write
+# (approve, merge, comment) happens through the GitHub App installation token
+# minted below, NOT through GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# One in-flight evaluation per PR; cancel stale runs on rapid synchronize.
+concurrency:
+  group: community-admin-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate-and-merge:
+    # Skip drafts outright; they are not ready and ready_for_review will fire
+    # the real evaluation when the author marks the PR ready.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the BASE branch ONLY. This is trusted, already-merged code.
+      # We never check out github.event.pull_request.head; the PR diff is read
+      # via the API in later steps. fetch-depth: 0 so we can `git show` the
+      # base and merge-base of config.yaml for the maintainers comparison.
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      # ----------------------------------------------------------------------
+      # Eligibility evaluation. This step writes ONE output: `eligible`
+      # (true/false) plus `community` and `reason` for logging/comments. It
+      # performs NO writes and uses only the read-only github.token to list the
+      # PR's changed files. Default posture is NOT eligible: any ambiguity,
+      # parse failure, or unexpected condition results in eligible=false.
+      # ----------------------------------------------------------------------
+      - name: Evaluate eligibility
+        id: eval
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Helper: emit outputs and exit "not eligible" cleanly (no-op, exit 0).
+          not_eligible() {
+            echo "::notice::Not eligible for auto-merge: $1"
+            {
+              echo "eligible=false"
+              echo "community="
+              echo "reason=$1"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # 1. Get the PR's changed files from the GitHub API. We do NOT diff
+          #    locally against PR-head code. --name-only across all statuses
+          #    (added/modified/removed/renamed). For a rename, gh lists the new
+          #    path; that still must fall under the community dir to be eligible.
+          mapfile -t CHANGED < <(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+
+          if [ "${#CHANGED[@]}" -eq 0 ]; then
+            not_eligible "PR changes zero files"
+          fi
+
+          echo "Changed files:"
+          printf '  %s\n' "${CHANGED[@]}"
+
+          # 2. Every changed path must match ^src/assistants/<id>/... and all
+          #    paths must resolve to the SAME single community id. A PR spanning
+          #    multiple communities, or touching anything outside a community
+          #    dir, is not eligible.
+          COMMUNITY=""
+          for f in "${CHANGED[@]}"; do
+            # Defense in depth: git reports normalized repo-relative paths, but
+            # reject anything containing a `..` segment or a leading slash just
+            # in case, so a path can never escape the community subtree.
+            if [[ "$f" == *"/../"* || "$f" == "../"* || "$f" == *"/.." || "$f" == /* ]]; then
+              not_eligible "path contains a parent-directory or absolute segment: $f"
+            fi
+
+            # Strict regex: literal prefix, one path segment (no slash, no `..`)
+            # as the id, then a slash and at least one more character (a real
+            # file under the dir, including files at the community root).
+            if [[ "$f" =~ ^src/assistants/([^/]+)/.+$ ]]; then
+              id="${BASH_REMATCH[1]}"
+            else
+              not_eligible "path outside a single community dir: $f"
+            fi
+
+            if [ -z "$COMMUNITY" ]; then
+              COMMUNITY="$id"
+            elif [ "$COMMUNITY" != "$id" ]; then
+              not_eligible "PR spans multiple communities ($COMMUNITY, $id)"
+            fi
+          done
+
+          if [ -z "$COMMUNITY" ]; then
+            not_eligible "could not determine a single community id"
+          fi
+
+          # Defense in depth: the path regex allows any non-slash characters in
+          # the id. Constrain it to a safe identifier (lowercase letters, digits,
+          # hyphen, underscore) before it is interpolated into git refs / paths,
+          # so a crafted path can never carry shell or ref metacharacters here.
+          if ! [[ "$COMMUNITY" =~ ^[a-z0-9_-]+$ ]]; then
+            not_eligible "community id has unexpected characters: $COMMUNITY"
+          fi
+          echo "Target community: $COMMUNITY"
+
+          CONFIG_PATH="src/assistants/$COMMUNITY/config.yaml"
+
+          # 3. The BASE branch must actually define this community with a
+          #    config.yaml. If the base has no such config (e.g. a brand-new
+          #    community introduced by this very PR), there is no trusted
+          #    maintainers list to authorize against -> human review.
+          if ! git cat-file -e "$BASE_SHA:$CONFIG_PATH" 2>/dev/null; then
+            not_eligible "no $CONFIG_PATH on base branch (new community needs human review)"
+          fi
+
+          # 4. SECURITY: read the maintainers list ONLY from the BASE branch
+          #    version of config.yaml. Never from the PR head. A parse failure
+          #    (malformed YAML, missing/empty maintainers) means not eligible.
+          git show "$BASE_SHA:$CONFIG_PATH" > /tmp/base_config.yaml || \
+            not_eligible "could not read base config.yaml"
+
+          # Extract a normalized (lowercased, sorted, newline-joined) maintainers
+          # list. Exit code 2 from the helper = parse/shape failure.
+          python - "$COMMUNITY" <<'PY' > /tmp/base_maintainers.txt || PARSE_RC=$?
+          import sys, yaml
+          community = sys.argv[1]
+          try:
+              with open("/tmp/base_config.yaml") as fh:
+                  data = yaml.safe_load(fh)
+          except Exception as exc:  # noqa: BLE001 - any parse error => ineligible
+              sys.stderr.write(f"base config.yaml failed to parse: {exc}\n")
+              sys.exit(2)
+          if not isinstance(data, dict):
+              sys.stderr.write("base config.yaml is not a mapping\n")
+              sys.exit(2)
+          maint = data.get("maintainers")
+          if not isinstance(maint, list) or not maint:
+              sys.stderr.write("base config.yaml has no non-empty maintainers list\n")
+              sys.exit(2)
+          names = []
+          for m in maint:
+              if not isinstance(m, str) or not m.strip():
+                  sys.stderr.write("maintainers entry is not a non-empty string\n")
+                  sys.exit(2)
+              names.append(m.strip().lower())
+          # Normalized, de-duplicated, sorted for stable comparison.
+          for n in sorted(set(names)):
+              print(n)
+          PY
+          PARSE_RC=${PARSE_RC:-0}
+          if [ "$PARSE_RC" -ne 0 ]; then
+            not_eligible "base config.yaml maintainers could not be parsed"
+          fi
+
+          # 5. SECURITY: if config.yaml is among the changed files, ensure the
+          #    PR does NOT modify the maintainers field. Changing who holds
+          #    admin power must go through human review. Compare the normalized
+          #    maintainers list of base vs head of config.yaml.
+          if printf '%s\n' "${CHANGED[@]}" | grep -qxF "$CONFIG_PATH"; then
+            echo "config.yaml is modified; verifying maintainers field is unchanged"
+
+            # Fetch the HEAD version of config.yaml via the API (raw contents at
+            # the PR head sha). We parse it ONLY to compare the maintainers
+            # field; we never execute it. A failure to fetch/parse the head
+            # config => not eligible (conservative default).
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            if ! gh api \
+                  -H "Accept: application/vnd.github.raw+json" \
+                  "/repos/$REPO/contents/$CONFIG_PATH?ref=$HEAD_SHA" \
+                  > /tmp/head_config.yaml 2>/dev/null; then
+              not_eligible "could not read head config.yaml for maintainers diff"
+            fi
+
+            python - "$COMMUNITY" <<'PY' > /tmp/head_maintainers.txt || HEAD_RC=$?
+          import sys, yaml
+          try:
+              with open("/tmp/head_config.yaml") as fh:
+                  data = yaml.safe_load(fh)
+          except Exception as exc:  # noqa: BLE001 - any parse error => ineligible
+              sys.stderr.write(f"head config.yaml failed to parse: {exc}\n")
+              sys.exit(2)
+          if not isinstance(data, dict):
+              sys.stderr.write("head config.yaml is not a mapping\n")
+              sys.exit(2)
+          maint = data.get("maintainers")
+          if not isinstance(maint, list):
+              sys.stderr.write("head config.yaml has no maintainers list\n")
+              sys.exit(2)
+          names = []
+          for m in maint:
+              if not isinstance(m, str) or not m.strip():
+                  sys.stderr.write("head maintainers entry is not a non-empty string\n")
+                  sys.exit(2)
+              names.append(m.strip().lower())
+          for n in sorted(set(names)):
+              print(n)
+          PY
+            HEAD_RC=${HEAD_RC:-0}
+            if [ "$HEAD_RC" -ne 0 ]; then
+              not_eligible "head config.yaml maintainers could not be parsed"
+            fi
+
+            if ! diff -q /tmp/base_maintainers.txt /tmp/head_maintainers.txt >/dev/null; then
+              not_eligible "PR modifies the maintainers field (needs human review)"
+            fi
+            echo "maintainers field unchanged; OK to proceed"
+          fi
+
+          # 6. Verify the PR author is in the BASE-branch maintainers list.
+          #    GitHub usernames are case-insensitive, so compare lowercased.
+          AUTHOR="$(printf '%s' "${{ github.event.pull_request.user.login }}" | tr '[:upper:]' '[:lower:]')"
+          echo "PR author (normalized): $AUTHOR"
+          if ! grep -qxF "$AUTHOR" /tmp/base_maintainers.txt; then
+            not_eligible "author '$AUTHOR' is not a maintainer of '$COMMUNITY'"
+          fi
+
+          # All checks passed.
+          echo "::notice::PR #$PR_NUMBER is eligible for auto-merge (community=$COMMUNITY, author=$AUTHOR)"
+          {
+            echo "eligible=true"
+            echo "community=$COMMUNITY"
+            echo "reason=author is a maintainer; changes scoped to $COMMUNITY"
+          } >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------------------------------------
+      # Mint the GitHub App installation token. Only reached when eligible.
+      # Short-lived; scoped to this repo by the App installation.
+      # ----------------------------------------------------------------------
+      - name: Mint GitHub App token
+        if: steps.eval.outputs.eligible == 'true'
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COMMUNITY_MERGE_APP_ID }}
+          private-key: ${{ secrets.COMMUNITY_MERGE_APP_PRIVATE_KEY }}
+
+      # Approve the PR using the App token. A clear, attributable review body.
+      - name: Approve PR
+        if: steps.eval.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMUNITY: ${{ steps.eval.outputs.community }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f event=APPROVE \
+            -f body="Auto-approved by community-admin auto-merge: changes are scoped to the **$COMMUNITY** community directory and the author is a listed maintainer. Required status checks still gate the merge."
+
+      # Enable squash auto-merge with the App token. Using --auto means the
+      # merge only happens once all required checks (ruff + tests) pass, so we
+      # never bypass CI. If the PR is already mergeable, GitHub merges
+      # immediately; otherwise it waits.
+      - name: Enable squash auto-merge
+        if: steps.eval.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+
+      # Post (find-or-update) a confirmation comment so we do not spam a new
+      # comment on every synchronize event. Uses the App token's identity.
+      - name: Comment confirmation
+        if: steps.eval.outputs.eligible == 'true'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const community = process.env.COMMUNITY;
+            const marker = '<!-- community-admin-merge -->';
+            const body = `${marker}\n` +
+              `Auto-merge enabled for the **${community}** community.\n\n` +
+              `This PR only touches \`src/assistants/${community}/\` and was opened by a ` +
+              `listed maintainer, so it has been approved and queued for **squash** auto-merge. ` +
+              `It will merge automatically once all required checks (ruff + tests) pass.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+        env:
+          COMMUNITY: ${{ steps.eval.outputs.community }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ src/
 - **.context/yaml_registry.md** - YAML-based community config (internal notes)
 - **.context/community_onboarding_review.md** - Onboarding gap analysis
 - **.context/local-testing-guide.md** - Quick local testing reference
+- **.context/community-admin-merge.md** - Maintainer auto-merge for community-scoped PRs (setup + trust model)
 - **Existing configs to reference**: `src/assistants/hed/config.yaml`, `src/assistants/eeglab/config.yaml`
 
 ### Tool System


### PR DESCRIPTION
## Summary
Lets a community maintainer auto-merge a PR that touches ONLY their own community's directory.

- New `.github/workflows/community-admin-pr-merge.yml`: on a PR to `develop` or `main`, approve + squash auto-merge only when the author is in the target community's `maintainers` list (read from the BASE branch), the diff touches only `src/assistants/<id>/**`, and the PR does not edit the `maintainers` field.
- Uses a dedicated GitHub App token (not the CI PAT); `pull_request_target` with base-only checkout never runs PR-head code; required CI checks still gate the merge; community-id is whitelisted before interpolation.
- Setup + trust-model doc: `.context/community-admin-merge.md`.

Closes #283

## Operator setup (one-time, GitHub side)
Create + install a GitHub App (Pull requests + Contents: read/write); add secrets `COMMUNITY_MERGE_APP_ID` and `COMMUNITY_MERGE_APP_PRIVATE_KEY`; enable Settings -> Allow auto-merge; add the App to any push allowlist on develop/main. See the doc for exact steps.

## Test plan
- Workflow YAML validated and every embedded bash step checked with `bash -n`.
- Eligibility/security checks documented and reviewed: author from base branch, single-community path scope, maintainers-field-edit exclusion, community-id whitelist, no PR-head execution.