### PR TITLE
fix(ci): pick community-admin merge method by target branch

### DIFF
--- a/.context/community-admin-merge.md
+++ b/.context/community-admin-merge.md
@@ -20,8 +20,9 @@ When a PR is opened, synchronized, reopened, or marked ready-for-review against
 4. Confirms the PR does NOT change the `maintainers:` field itself (a covert
    admin-list change is rejected before the author is even considered).
 5. Confirms the PR author is in that list (case-insensitive).
-6. If all checks pass: approves the PR and enables a SQUASH auto-merge using a
-   dedicated GitHub App token. The merge fires only after required checks pass.
+6. If all checks pass: approves the PR and enables auto-merge using a dedicated
+   GitHub App token (squash into `develop`, merge-commit into `main`, matching
+   the branch rulesets). The merge fires only after required checks pass.
 
 If any check fails, or anything is ambiguous, the workflow no-ops (logs a notice
 and exits cleanly). The PR then follows the normal human-review path. Default
@@ -77,7 +78,7 @@ GitHub Apps -> New GitHub App.
   minting a token, the App does not need to receive events.
 - Repository permissions (set ONLY these; leave everything else "No access"):
   - Pull requests: Read and write  (needed to approve and to enable auto-merge)
-  - Contents: Read and write       (needed for the squash merge to write the commit)
+  - Contents: Read and write       (needed for the merge to write the commit)
   - Metadata: Read-only            (mandatory; GitHub sets this automatically)
 - Organization permissions: none.
 - Account permissions: none.
@@ -138,8 +139,9 @@ the repo). Make sure the App is allowed to merge:
 2. Make sure you are a listed maintainer in that directory's `config.yaml`.
 3. Do not change the `maintainers:` field in the same PR; that needs human
    review.
-4. The workflow approves the PR and enables squash auto-merge. The PR merges
-   automatically once ruff and the test suite pass. A confirmation comment is
+4. The workflow approves the PR and enables auto-merge (squash into develop,
+   merge-commit into main). The PR merges automatically once ruff and the test
+   suite pass. A confirmation comment is
    posted (and updated in place on later pushes, not duplicated).
 
 If your PR is not eligible (touches more than one community, touches files

--- a/.github/workflows/community-admin-pr-merge.yml
+++ b/.github/workflows/community-admin-pr-merge.yml
@@ -2,8 +2,8 @@ name: Community Admin PR Auto-Merge
 
 # Lets a community maintainer auto-merge a PR that ONLY touches their own
 # community's directory (src/assistants/<id>/**). When eligible, this workflow
-# approves the PR and enables squash auto-merge so the normal required status
-# checks (ruff + tests) still gate the actual merge.
+# approves the PR and enables auto-merge (squash into develop, merge-commit into
+# main) so the normal required status checks (ruff + tests) still gate the merge.
 #
 # -----------------------------------------------------------------------------
 # Trigger choice: pull_request_target (NOT pull_request)
@@ -330,19 +330,28 @@ jobs:
             -f event=APPROVE \
             -f body="Auto-approved by community-admin auto-merge: changes are scoped to the **$COMMUNITY** community directory and the author is a listed maintainer. Required status checks still gate the merge."
 
-      # Enable squash auto-merge with the App token. Using --auto means the
-      # merge only happens once all required checks (ruff + tests) pass, so we
-      # never bypass CI. If the PR is already mergeable, GitHub merges
-      # immediately; otherwise it waits.
-      - name: Enable squash auto-merge
+      # Enable auto-merge with the App token. --auto means the merge happens only
+      # once all required checks (ruff + tests) pass, so we never bypass CI. The
+      # merge method is chosen by target branch to satisfy the branch rulesets:
+      # develop allows squash (feature-branch convention); main is merge-commit
+      # only (the develop->main release convention). Using --squash on a main PR
+      # would be rejected by the protect-main ruleset.
+      - name: Enable auto-merge
         if: steps.eval.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+          if [ "$BASE_REF" = "main" ]; then
+            METHOD="--merge"
+          else
+            METHOD="--squash"
+          fi
+          echo "Merging PR #$PR_NUMBER into $BASE_REF with $METHOD"
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto "$METHOD"
 
       # Post (find-or-update) a confirmation comment so we do not spam a new
       # comment on every synchronize event. Uses the App token's identity.
@@ -358,7 +367,7 @@ jobs:
             const body = `${marker}\n` +
               `Auto-merge enabled for the **${community}** community.\n\n` +
               `This PR only touches \`src/assistants/${community}/\` and was opened by a ` +
-              `listed maintainer, so it has been approved and queued for **squash** auto-merge. ` +
+              `listed maintainer, so it has been approved and queued for auto-merge. ` +
               `It will merge automatically once all required checks (ruff + tests) pass.`;
 
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary
The community-admin auto-merge workflow (#285) always called `gh pr merge --auto --squash`, but the `protect-main` ruleset only allows merge-commits (`allowed_merge_methods: ['merge']`). A community PR targeting **main** would therefore fail at the merge step.

- Choose the method by target branch: **--squash into develop**, **--merge into main** (matches the develop->main release convention and the rulesets).
- Updated the confirmation comment, header comment, and `.context/community-admin-merge.md` to stop hardcoding 'squash'.

Closes #290

## Test plan
- YAML + every embedded bash step validated (`bash -n`).
- Logic: `BASE_REF == main -> --merge`, else `--squash`; passed via env (no ${{ }} in the shell body).