### PR TITLE
chore: add neuromechanist as maintainer of HED, EEGLAB, NEMAR

### DIFF
--- a/src/assistants/eeglab/config.yaml
+++ b/src/assistants/eeglab/config.yaml
@@ -35,6 +35,7 @@ cors_origins:
 # Used for scoped admin access and budget alert @mentions
 maintainers:
   - arnodelorme
+  - neuromechanist
 
 # Budget limits for cost management
 budget:

--- a/src/assistants/hed/config.yaml
+++ b/src/assistants/hed/config.yaml
@@ -33,6 +33,7 @@ openrouter_api_key_env_var: "OPENROUTER_API_KEY_HED"
 maintainers:
   - VisLab
   - yarikoptic
+  - neuromechanist
 
 # Budget limits for cost management
 budget:

--- a/src/assistants/nemar/config.yaml
+++ b/src/assistants/nemar/config.yaml
@@ -33,6 +33,7 @@ cors_origins:
 # Community maintainers (GitHub usernames)
 maintainers:
   - arnodelorme
+  - neuromechanist
 
 # Budget limits for cost management
 budget:


### PR DESCRIPTION
Adds the OSC owner (`neuromechanist`) to the `maintainers` list of HED, EEGLAB, and NEMAR.

This PR edits the `maintainers` field across three communities, so the community-admin auto-merge workflow will correctly treat it as **not eligible** (maintainers-field edit + multi-community) — it will be merged manually.

Closes #292