### PR TITLE
test: community-admin auto-merge (HED scoped, comment only)

### DIFF
--- a/src/assistants/hed/config.yaml
+++ b/src/assistants/hed/config.yaml
@@ -462,3 +462,7 @@ extensions:
         - validate_hed_string
         - suggest_hed_tags
         - get_hed_schema_versions
+
+# Community maintainers listed above may open scoped PRs (touching only
+# this directory) that auto-approve and auto-merge via the community-admin
+# merge workflow.


### PR DESCRIPTION
End-to-end test of the community-admin auto-merge workflow now that it's registered on main.

- Author: neuromechanist (a HED maintainer on the base branch).
- Touches only `src/assistants/hed/` (a comment), and does NOT change the maintainers field.

Expected: the workflow evaluates this as eligible, the App approves it, and it auto-merges (squash) once CI passes.