### PR TITLE
test: LGTM/merge comment command (HED scoped)

### DIFF
--- a/src/assistants/hed/config.yaml
+++ b/src/assistants/hed/config.yaml
@@ -466,3 +466,4 @@ extensions:
 # Community maintainers listed above may open scoped PRs (touching only
 # this directory) that auto-approve and auto-merge via the community-admin
 # merge workflow.
+# (verifying the LGTM/merge comment command)


### PR DESCRIPTION
Testing the comment-command merge. I'll comment 'LGTM, please merge'; expected: the App squash-merges it (nothing merged on open).