### PR TITLE
fix(ci): ignore bot comments in the community merge command

### DIFF
--- a/.github/workflows/community-admin-pr-merge.yml
+++ b/.github/workflows/community-admin-pr-merge.yml
@@ -50,8 +50,12 @@ concurrency:
 
 jobs:
   merge-on-command:
-    # Only comments on pull requests (issue_comment also fires on plain issues).
-    if: github.event.issue.pull_request != null
+    # Only human comments on pull requests. issue_comment also fires on plain
+    # issues (filtered out), and on the App's own confirmation comment (which
+    # mentions "LGTM / merge") -- skipping Bot authors stops that self-trigger.
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       # Cheap first gate: does the comment carry the "LGTM ... merge" command?


### PR DESCRIPTION
The App's confirmation comment contains 'LGTM / merge', so it re-triggered the `issue_comment` workflow, which then no-op'd (bot is not a maintainer) -- one harmless extra run per merge.

Add `github.event.comment.user.type != 'Bot'` to the job `if:` so the App's own comment (and any bot) no longer self-triggers the workflow.

Closes #302

## Test plan
- YAML validated. After merge + main sync: a LGTM/merge command still merges, but the App's confirmation comment no longer spawns a second run.