### PR TITLE
ci: sync bot-comment guard to main

### DIFF
--- a/.github/workflows/community-admin-pr-merge.yml
+++ b/.github/workflows/community-admin-pr-merge.yml
@@ -50,8 +50,12 @@ concurrency:
 
 jobs:
   merge-on-command:
-    # Only comments on pull requests (issue_comment also fires on plain issues).
-    if: github.event.issue.pull_request != null
+    # Only human comments on pull requests. issue_comment also fires on plain
+    # issues (filtered out), and on the App's own confirmation comment (which
+    # mentions "LGTM / merge") -- skipping Bot authors stops that self-trigger.
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       # Cheap first gate: does the comment carry the "LGTM ... merge" command?


### PR DESCRIPTION
Syncs the merge workflow bot-guard (#303) to main so the registered (default-branch) version ignores the App's own confirmation comment. No app/version change.