### PR TITLE
fix(ci): repair invalid YAML in release.yml (startup failures)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,28 +67,35 @@ jobs:
               content = f.read()
           print('sha384-' + base64.b64encode(hashlib.sha384(content).digest()).decode())
           ")
-          python3 - <<PYEOF
+          export OSA_VERSION="$VERSION"
+          export OSA_SRI="$HASH"
+          python3 - <<'PYEOF'
+          import os
           import pathlib
-          notes = pathlib.Path('/tmp/release_notes.md').read_text()
-          section = f"""
-      
-      ## Widget Embedding
-      
-      **Standard** (always latest):
-      \`\`\`html
-      <script src="https://demo.osc.earth/osa-chat-widget.js"></script>
-      \`\`\`
-      
-      **Versioned + SRI** (for supply-chain-secure environments):
-      \`\`\`html
-      <script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@v${VERSION}/frontend/osa-chat-widget.js"
-              integrity="${HASH}"
-              crossorigin="anonymous"
-              defer></script>
-      \`\`\`
-      > Pin to this exact release. Update the tag when upgrading.
-      """
-          pathlib.Path('/tmp/release_notes.md').write_text(notes + section)
+
+          version = os.environ["OSA_VERSION"]
+          sri = os.environ["OSA_SRI"]
+          section = [
+              "",
+              "## Widget Embedding",
+              "",
+              "**Standard** (always latest):",
+              "```html",
+              '<script src="https://demo.osc.earth/osa-chat-widget.js"></script>',
+              "```",
+              "",
+              "**Versioned + SRI** (for supply-chain-secure environments):",
+              "```html",
+              f'<script src="https://cdn.jsdelivr.net/gh/OpenScience-Collective/osa@v{version}/frontend/osa-chat-widget.js"',
+              f'        integrity="{sri}"',
+              '        crossorigin="anonymous"',
+              "        defer></script>",
+              "```",
+              "> Pin to this exact release. Update the tag when upgrading.",
+              "",
+          ]
+          path = pathlib.Path("/tmp/release_notes.md")
+          path.write_text(path.read_text() + "\n".join(section))
           PYEOF
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Problem (#311)

`release.yml` was producing a **failed run on every push** to develop and feature branches, even though its trigger is tags-only (`push.tags: ['v*']`). These were **startup failures** (zero jobs): the workflow file was **invalid YAML**, so GitHub couldn't parse it to apply the tag filter.

Root cause: the `Append widget SRI hash` step's markdown heredoc was indented to 6 spaces inside a `run: |` block whose content base is 10 spaces. That terminated the YAML block scalar early; the parser then hit `**Standard**` and read `*` as a YAML alias -> `ScannerError` at line 77. (The step was added after the 0.8.3 release, which is why earlier releases worked.)

## Fix

Rewrote the step to keep all content inside the block scalar: pass `version`/`hash` via env vars into a quoted heredoc (`<<'PYEOF'`) and build the notes section as an explicit list of lines (no indentation-sensitive triple-quoted markdown).

## Verified locally

- `yaml.safe_load` now parses; trigger remains `push.tags: ['v*']`; all 5 steps intact.
- Simulated the step: the rendered Widget Embedding section is correct (clean code fences, version + SRI hash injected).

After merge, pushes will no longer show spurious `release.yml` failures, and a real `v*` tag will create the GitHub release as intended.