### PR TITLE
fix(ci): repair recurring sync-develop checkout failure

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -30,14 +30,26 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout develop
+      # Check out main, not develop: under the workflow_run trigger the
+      # checkout action's wildcard fetch (+refs/heads/*) intermittently
+      # advertises only `main`, so `ref: develop` fails with "a branch or tag
+      # with the name 'develop' could not be found" (broke every release through
+      # v0.8.4). main is always advertised; we fetch develop by explicit name
+      # in the next step, which requests the ref directly and is reliable.
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
           # CI_ADMIN_TOKEN lets this push to develop without tripping
           # branch protection (same pattern as ensure-stable-version.yml).
           token: ${{ secrets.CI_ADMIN_TOKEN }}
+
+      - name: Check out develop by explicit ref
+        run: |
+          git fetch origin +refs/heads/develop:refs/remotes/origin/develop
+          git checkout -B develop refs/remotes/origin/develop
+          git log --oneline -1
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem

`sync-develop.yml` ("Sync develop with main and bump") has failed on **every** stable release (verified on v0.8.3 and v0.8.4), leaving develop unsynced after each release. It dies at the checkout step:

```
##[error]A branch or tag with the name 'develop' could not be found
```

The full log shows the cause: under the `workflow_run` trigger, `actions/checkout`'s wildcard fetch

```
git fetch ... origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
 * [new branch]      main        -> origin/main
 * [new tag]         v0.8.4 ...
```

advertises **only `main`** among heads. develop is never fetched, so `ref: develop` can't be resolved. (The token is valid: it authenticates and fetches main + all tags.)

## Fix

Check out `main` (always advertised), then fetch develop by **explicit named ref** and check it out. A named-ref fetch requests the ref directly and is reliable, unlike the wildcard advertisement.

```yaml
- name: Checkout main
  uses: actions/checkout@v4
  with:
    ref: main
    fetch-depth: 0
    token: ${{ secrets.CI_ADMIN_TOKEN }}
- name: Check out develop by explicit ref
  run: |
    git fetch origin +refs/heads/develop:refs/remotes/origin/develop
    git checkout -B develop refs/remotes/origin/develop
```

The remaining steps (validate main version, `merge --no-ff origin/main`, bump to `<next-patch>.dev0`, push) are unchanged and operate on the now-checked-out develop.

## Verification

YAML validated; step order preserved. The real test is the next stable release: the workflow should merge main into develop and bump automatically, with no manual sync. For v0.8.4 the sync was performed manually (develop is already at `0.8.5.dev0`).
