### PR TITLE
Add BIDS RTD PR-preview origins to CORS (temporary)

### DIFF
--- a/src/assistants/bids/config.yaml
+++ b/src/assistants/bids/config.yaml
@@ -20,6 +20,12 @@ enable_page_context: true
 cors_origins:
   - https://bids.neuroimaging.io
   - https://bids-specification.readthedocs.io
+  # Temporary: ReadTheDocs PR preview builds, so reviewers can try the widget
+  # before merge. Remove once these PRs are merged:
+  #   bids-standard/bids-specification#2442  (spec site)
+  #   bids-standard/bids-website#847         (website)
+  - https://bids-specification--2442.org.readthedocs.build
+  - https://bids-website--847.org.readthedocs.build
 
 # Per-community OpenRouter API key (optional)
 openrouter_api_key_env_var: "OPENROUTER_API_KEY_BIDS"


### PR DESCRIPTION
## Summary

Adds the ReadTheDocs PR-preview origins for the two BIDS widget PRs to the BIDS community `cors_origins` so reviewers can actually try the assistant on the preview builds:

- https://bids-specification--2442.org.readthedocs.build (bids-standard/bids-specification#2442)
- https://bids-website--847.org.readthedocs.build (bids-standard/bids-website#847)

The RTD preview hosts resolve to the production OSA worker (the widget's env-detection treats `*.org.readthedocs.build` as neither dev nor demo), so these origins are needed on prod for the preview pages to call the API.

## Temporary

Both entries are clearly commented as temporary and should be removed once the two upstream PRs merge (the permanent `bids.neuroimaging.io` and `bids-specification.readthedocs.io` origins already cover the live sites).

## Testing

- `CommunityConfig` parses the updated YAML and both new origins pass the `cors_origins` validator.

## Deploy note

CORS is built at FastAPI startup from each community config, so this needs a backend restart/redeploy to take effect on the environment serving the preview (production).