### PR TITLE
feat(eeglab): enable public FAQ and citations feeds

### DIFF
--- a/src/assistants/eeglab/config.yaml
+++ b/src/assistants/eeglab/config.yaml
@@ -427,6 +427,12 @@ citations:
     - "10.1016/j.neuroimage.2019.05.026"  # ICLabel: automated EEG IC classification (Pion-Tonachini et al., 2019)
     - "10.3389/fninf.2015.00016"  # PREP: standardized preprocessing (Bigdely-Shamlo et al., 2015)
 
+# Expose generated FAQ entries and citation stats as public, read-only JSON feeds
+# (GET /eeglab/faq and GET /eeglab/citations). Off by default platform-wide.
+public_feeds:
+  faq: true
+  citations: true
+
 # Mailing list configuration for FAQ generation
 mailman:
   - list_name: eeglablist


### PR DESCRIPTION
## Summary

Enables the two public JSON feeds (from epic #321) for the eeglab community:

```yaml
public_feeds:
  faq: true
  citations: true
```

- `GET /eeglab/faq` — generated FAQ entries (1,990 on dev)
- `GET /eeglab/citations` — per-year + stacked-by-paper citation stats

## Notes

`citations.by_paper` populates once the `cites_doi` backfill re-sync runs on the dev container (the schema migration adds the column on the next deploy). `per_year` and the FAQ feed work immediately against existing data.

## Test plan

- Config loads and validates: `public_feeds.faq` and `public_feeds.citations` resolve to `True` for eeglab.