### PR TITLE
chore: sync develop with main after v0.8.7

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.8.7"
-__version_info__ = (0, 8, 7)
+__version__ = "0.8.8.dev0"
+__version_info__ = (0, 8, 8, "dev")
 
 
 def get_version() -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.8.7.dev0"
-__version_info__ = (0, 8, 7, "dev")
+__version__ = "0.8.7"
+__version_info__ = (0, 8, 7)
 
 
 def get_version() -> str:


### PR DESCRIPTION
Manual recovery for the post-release develop sync. The automated `Sync develop with main and bump` workflow failed again on the v0.8.7 release: the checkout fix (#318) held, but the push to `develop` is now rejected by branch-protection rules (`GH013`) because the Actions bot lacks bypass.

This PR does what the workflow would have done:
- Merge `main` (v0.8.7) back into `develop`.
- Bump `develop` to `0.8.8.dev0`.

Merge with a **merge commit** to preserve the sync linkage. `Bump version to 0.8.8.dev0` self-skips `auto-bump-dev.yml`.