### PR TITLE
chore: sync develop with main after v0.8.8

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.8.8.dev0"
-__version_info__ = (0, 8, 8, "dev")
+__version__ = "0.8.8"
+__version_info__ = (0, 8, 8)
 
 
 def get_version() -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for OSA."""
 
-__version__ = "0.8.8"
-__version_info__ = (0, 8, 8)
+__version__ = "0.8.9.dev0"
+__version_info__ = (0, 8, 9, "dev")
 
 
 def get_version() -> str:


### PR DESCRIPTION
Manual recovery for the post-release develop sync (the automated workflow fails on the branch-protection push). Merges main (v0.8.8) into develop and bumps to 0.8.9.dev0. Merge with a **merge commit**.